### PR TITLE
[fix bug 998236] Privacy policy url fixed

### DIFF
--- a/extensions/BMO/template/en/default/hook/global/footer-end.html.tmpl
+++ b/extensions/BMO/template/en/default/hook/global/footer-end.html.tmpl
@@ -7,5 +7,5 @@
   #%]
 
 <div id="privacy-policy">
-  <a href="https://www.mozilla.org/about/policies/privacy-policy.html" target="_blank">Privacy Policy</a>
+  <a href="https://www.mozilla.org/privacy/websites/" target="_blank">Privacy Policy</a>
 </div>


### PR DESCRIPTION
The url for the privacy policy has changed from http://www.mozilla.org/privacy-policy.html to http://www.mozilla.org/privacy/websites/

We should update the /about/ page to reflect this.
