### PR TITLE
Bug 1501888 - Implement Bugzilla::Util::remote_ip() in terms of Mojolicious API

### DIFF
--- a/Bugzilla/Quantum.pm
+++ b/Bugzilla/Quantum.pm
@@ -42,6 +42,7 @@ sub startup {
     unless $ENV{BUGZILLA_DISABLE_HOSTAGE};
   $self->plugin('Bugzilla::Quantum::Plugin::SizeLimit')
     unless $ENV{BUGZILLA_DISABLE_SIZELIMIT};
+  $self->plugin('ForwardedFor') if Bugzilla->has_feature('better_xff');
   $self->plugin('Bugzilla::Quantum::Plugin::BlockIP');
   $self->plugin('Bugzilla::Quantum::Plugin::Helpers');
 

--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -326,7 +326,8 @@ sub remote_ip {
     if ($ENV{SERVER_SOFTWARE} eq 'Bugzilla::Quantum::CGI') {
         my $c = $Bugzilla::Quantum::CGI::C
             or LOGDIE("Cannot find controller!");
-        return $c->tx->remote_address
+        state $better_xff = Bugzilla->has_feature('better_xff');
+        return $better_xff ? $c->forwarded_for : $c->tx->remote_address;
     }
     else {
         WARN("remote_ip() called outside CGI controller!");

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -129,6 +129,11 @@ if ($OSNAME eq 'linux' && -f '/etc/debian_version') {
 }
 
 my %optional_features = (
+  better_xff => {
+    description => 'Improved behavior of MOJO_REVERSE_PROXY',
+    prereqs =>
+      {runtime => {requires => {'Mojolicious::Plugin::ForwardedFor' => 0}}}
+  },
   alien_cmark => {
     description => 'Support GitHub-flavored markdown',
     prereqs     => {runtime => {requires => {'Alien::libcmark_gfm' => '3'},},},
@@ -300,7 +305,10 @@ my %optional_features = (
   },
   linux_smaps => {
     description => 'Linux::Smaps::Tiny for limiting memory usage',
-    prereqs     => {runtime => {requires => {'Linux::Smaps::Tiny' => '0', 'BSD::Resource' => 0}}},
+    prereqs     => {
+      runtime =>
+        {requires => {'Linux::Smaps::Tiny' => '0', 'BSD::Resource' => 0}}
+    },
   },
   linux_pdeath => {
     description => 'Linux::Pdeathsig for a good parent/child relationships',


### PR DESCRIPTION
A reasonable thing here is perhaps to just always require Mojolicious::Plugin::ForwardedFor.
What do you think?