### PR TITLE
Bug 1575881 - Bug open/updated/closed date, reporter and triage owner should be visible in Edit mode

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -275,7 +275,7 @@
           <span class="edit-hide">([% bug.alias FILTER html %])</span>
         [% END %]
       </span>
-      <span class="edit-hide">
+      <span>
         <span class="bug-time-label">Opened [% INCLUDE bug_modal/rel_time.html.tmpl ts=bug.creation_ts %]</span>
         [% IF !bug.isopened %]
           <span class="bug-time-label">Closed [% INCLUDE bug_modal/rel_time.html.tmpl ts=bug.cf_last_resolved %]</span>
@@ -803,7 +803,6 @@
         field = bug_fields.reporter
         field_type = constants.FIELD_TYPE_USER
         view_only = 1
-        hide_on_edit = 1
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#reporter"
     %]
 
@@ -814,7 +813,6 @@
         value = bug.component_obj.triage_owner
         view_only = 1
         hide_on_view = bug.component_obj.triage_owner.login == ""
-        hide_on_edit = 1
         help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#triage_owner"
     %]
 


### PR DESCRIPTION
Show the Opened, Updated and Closed dates on the modal UI header as well as the read-only Reporter and Triage Owner fields even in the Edit mode, because some people are using “Always Enable Edit Mode” to skip the View mode.

## Bugzilla link

[Bug 1575881 - Bug open/updated/closed date, reporter and triage owner should be visible in Edit mode](https://bugzilla.mozilla.org/show_bug.cgi?id=1575881)