### PR TITLE
Bug 1721080 - don't show incorrect MTA in bounce error

### DIFF
--- a/template/en/default/admin/users/bounce-disabled.txt.tmpl
+++ b/template/en/default/admin/users/bounce-disabled.txt.tmpl
@@ -16,4 +16,4 @@
 Your [% terms.Bugzilla %] account has been disabled due to issues delivering
 emails to your address.<br>
 <br>
-Your mail server ([% mta FILTER html %]) said: [% reason FILTER html %]<br>
+Your mail server said: [% reason FILTER html %]<br>


### PR DESCRIPTION
Currently the `reportingMTA` is always AWS SMTP servers, which is
incorrect and leads to confusion.  Remove it from the bounce message.