### PR TITLE
Bug 1696781 - Disable OAuth2 integration in createaccount.cgi, and enable it in token.cgi after creating account.

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -284,6 +284,14 @@ sub login {
   my $do_logout     = $cgi->param('logout');
   my $on_token_page = $script_name eq '/token.cgi';
 
+  my $is_creatingaccount = 0;
+  if ($script_name eq '/createaccount.cgi'
+    || ($on_token_page && !$cgi->param('token_account_created')))
+  {
+    # The user hasn't yet created account.
+    $is_creatingaccount = 1;
+  }
+
   if ($authenticated_user->password_change_required) {
 
     # We cannot show the password reset UI for API calls, so treat those as
@@ -388,9 +396,10 @@ sub login {
   }
 
   # If Mojo native app is requesting login, we need to possibly redirect
+  # If the user is creating account, we should wait until the process finishes.
   my $C = Bugzilla->request_cache->{mojo_controller};
   my $session = $C->session;
-  if (!$on_token_page && $session->{override_login_target}) {
+  if (!$is_creatingaccount && $session->{override_login_target}) {
     my $override_login_target = delete $session->{override_login_target};
     my $cgi_params            = delete $session->{cgi_params};
     my $mojo_url              = Mojo::URL->new($override_login_target);

--- a/token.cgi
+++ b/token.cgi
@@ -449,6 +449,7 @@ sub confirm_create_account {
   # Log in the new user using credentials they just gave.
   $cgi->param('Bugzilla_login',    $otheruser->login);
   $cgi->param('Bugzilla_password', $password1);
+  $cgi->param('token_account_created', 1);
   Bugzilla->login(LOGIN_OPTIONAL);
 
   print $cgi->header();


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1696781

This fixes 2 issues:

1) In the current code, the redirect for OAuth2 is disabled only for `token.cgi`.
That means, if the user arrives bugzilla without an account, they cannot create account in `createaccount.cgi`.

2) In the current code, the redirect for OAuth2 is disabled for `token.cgi`, even after creating account.
That means, the user cannot continue OAuth2 process until they click some link in the page.

This patch fixes the above by:
  1. disble OAuth2 redirect for `createaccount.cgi`
  2. enable Oauth2 redirect for `token.cgi` if the account is created

I used `$cgi->param('token_account_created')` to pass that information from `token.cgi` to `Bugzilla->login`.
If there's better way that won't break any other code, let me know.
