### PR TITLE
Bug 1820859 - Wrap code that looks for a latest nightly/stable versions of Firefox in try/catch block in case of failure

### DIFF
--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -386,7 +386,7 @@ sub _set_status_flag {
   my $version;
   if ($branch eq 'main' || $branch eq 'master') {
     my $versions = fetch_product_versions('firefox');
-    return if (!%$versions || !exists $versions->{FIREFOX_NIGHTLY});
+    return if (!$versions || !exists $versions->{FIREFOX_NIGHTLY});
     ($version) = split /[.]/, $versions->{FIREFOX_NIGHTLY};
   }
   # Release branches already have the version number embedded in the name.
@@ -438,7 +438,7 @@ sub _set_nightly_milestone {
   # fetch_product_versions() calls an API endpoint maintained by rel-eng that
   # returns all of the current product versions so we can use that.
   my $versions = fetch_product_versions('firefox');
-  return if (!%$versions || !exists $versions->{FIREFOX_NIGHTLY});
+  return if (!$versions || !exists $versions->{FIREFOX_NIGHTLY});
   my ($version) = split /[.]/, $versions->{FIREFOX_NIGHTLY};
   return if !$version;
 

--- a/Bugzilla/App/BMO/NewRelease.pm
+++ b/Bugzilla/App/BMO/NewRelease.pm
@@ -49,6 +49,8 @@ sub new_release {
   # Display the initial form
   if ($self->req->method eq 'GET') {
     my $versions          = fetch_product_versions('firefox');
+    return $self->code_error() if !$versions;
+
     my $latest_nightly    = $versions->{FIREFOX_NIGHTLY};
     my ($current_nightly) = $latest_nightly =~ /^(\d+)/;
 

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -2656,7 +2656,7 @@ sub _split_crash_signature {
 sub _get_product_version {
   my ($product, $channel, $detail) = @_;
   my $versions = fetch_product_versions($product);
-  return 0 unless %$versions;
+  return 0 unless $versions;
 
   my $version = $versions->{PRODUCT_CHANNELS->{$product}->{$channel}->{json_key}};
   return $version if $detail;
@@ -2749,9 +2749,13 @@ sub search_date_pronoun {
   my $keys = ['LAST_MERGE_DATE', 'LAST_RELEASE_DATE', 'LAST_SOFTFREEZE_DATE'];
   return unless grep(/^$key$/, @$keys);
 
-  my $date = fetch_product_versions('firefox')->{$key};
-  ThrowUserError('product_date_pronouns_unavailable') unless $date;
-  $pronoun->{date} = $date;
+  my $versions = fetch_product_versions('firefox');
+  if (!$versions || !$versions->{$key}) {
+    WARN("product_date_pronouns_unavailable");
+    ThrowUserError('product_date_pronouns_unavailable');
+  }
+
+  $pronoun->{date} = $versions->{$key};
 }
 
 sub tf_buglist_columns {

--- a/extensions/MozChangeField/lib/Post/SetTrackingSeverityS1.pm
+++ b/extensions/MozChangeField/lib/Post/SetTrackingSeverityS1.pm
@@ -117,7 +117,7 @@ sub evaluate_change {
 
 sub _fetch_nightly_beta_versions {
   my $versions  = fetch_product_versions('firefox');
-  if (!%$versions
+  if (!$versions
     || !exists $versions->{FIREFOX_NIGHTLY}
     || !exists $versions->{LATEST_FIREFOX_RELEASED_DEVEL_VERSION}
   ) {


### PR DESCRIPTION
I would still like to see this change merged and now that it doesn't seem to be the reason behind the tracking flag errors (which caused us to revert) I am submitting once more for review. I have change some to make the code more easy to follow and to make the caller decide what to do if the data is not returned properly.