### PR TITLE
Bug 1954571 - Fix image build and push to GAR workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - release-**
-  workflow_dispatch: {}
 
 env:
   IMAGE_NAME: mozilla-bteam/bmo


### PR DESCRIPTION
We fixed the permissions issues on the GCP side that were blocking us from being able to upload to GAR. This PR now fixes the workflow itself. Once this is merged, tags matching the `release-**` pattern should be automatically built and pushed to GAR.

Changes:
- Use `v4` version of checkout and upload-artifacts actions
- Fix `docker cp` command syntax in `Copy version.json and build push data` step