### PR TITLE
Bug 1954833 - Change product name from "Fenix" to "Firefox for Android"

### DIFF
--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -107,7 +107,7 @@ use Time::HiRes qw(gettimeofday tv_interval);
 # Constants #
 #############
 
-# BMO - product aliases for searchi`ng
+# BMO - product aliases for searching
 use constant PRODUCT_ALIASES => {
   'Fenix' => 'Firefox for Android',
 };


### PR DESCRIPTION
When someone enters Fenix as a product from a saved query or from some wiki/dashboard, this will automatically update it to Firefox for Android. We will rename the product at the same time that this change is deployed live.