### PR TITLE
Bug 1988539 - Adding a comment to bug with a user story value with editbugs permission causes a permission error and the comment cannot be added

### DIFF
--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -1276,17 +1276,18 @@
           <button type="button" class="secondary" id="user-story-edit-btn" aria-label="Edit User Story">Edit</button>
         [% END %]
         [% IF bug.cf_user_story != "" && bug.check_can_change_field('longdesc', 0, 1).allowed %]
-          <button type="button" class="secondary" id="user-story-reply-btn" aria-label="Reply to User Story">Reply</button>
+          <button type="button" class="secondary" id="user-story-reply-btn" aria-label="Reply to User Story"
+                  data-user-story="[% bug.cf_user_story FILTER html %]">Reply</button>
+        [% END %]
+        [% IF bug.check_can_change_field('cf_user_story', 0, 1).allowed %]
+          <textarea id="cf_user_story" name="cf_user_story" style="display:none" rows="10" cols="80"
+                   aria-label="User Story">
+            [%~ bug.cf_user_story FILTER html ~%]
+          </textarea>
         [% END %]
       </div>
     [% END %]
     <pre id="user-story">[% bug.cf_user_story FILTER quoteUrls(bug) %]</pre>
-    [% IF user.id %]
-      <textarea id="cf_user_story" name="cf_user_story" style="display:none" rows="10" cols="80"
-                aria-label="User Story">
-        [%~ bug.cf_user_story FILTER html ~%]
-      </textarea>
-    [% END %]
   [% END %]
 [% END %]
 

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1183,7 +1183,7 @@ $(function() {
     $('#user-story-reply-btn')
         .click(function(event) {
             event.preventDefault();
-            var text = "(Commenting on User Story)\n" + wrapReplyText($('#cf_user_story').val());
+            var text = "(Commenting on User Story)\n" + wrapReplyText($('#user-story-reply-btn').data('user-story'));
             var current = $('#comment', '#changeform').val();
             if (current != text) {
                 $('#comment', '#changeform').val(current + text);


### PR DESCRIPTION
This change removes the hidden text area for users who cannot edit the user story field. This keeps the field from being updated by non-permitted users in any circumstance such line ending changes, etc. It adds the current user story text as a data field to the reply button to allow adding the text to the comment text area. Originally the old hidden text area was serving this purpose.