### PR TITLE
Bug 1992731 - Hide gravatar / user image for disabled users

### DIFF
--- a/extensions/Gravatar/Extension.pm
+++ b/extensions/Gravatar/Extension.pm
@@ -27,8 +27,13 @@ BEGIN {
 
 sub _user_gravatar {
   my ($self, $size) = @_;
-  if ($self->setting('show_my_gravatar')
-    && $self->setting('show_my_gravatar') eq 'Off')
+  if (
+    (
+         $self->setting('show_my_gravatar')
+      && $self->setting('show_my_gravatar') eq 'Off'
+    )
+    || !$self->is_enabled
+    )
   {
     return DEFAULT_URL;
   }


### PR DESCRIPTION
Updates `user->gravatar` to return the default generic image if users account is disabled.