### PR TITLE
Bug 2023761 - [GITHUB] Allow use of individual api keys for pull requests and push comments instead of single share secret

### DIFF
--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -385,9 +385,19 @@ sub _verify_signature {
 
   return 0 if !$received_signature;
 
-  # Fetch all non-revoked API keys for users in the github-webhook-bot group.
+  # Fast path: check legacy shared secret first during migration period.
+  # Operators should migrate to per-bot API keys and clear this parameter.
+  my $legacy_secret = Bugzilla->params->{github_pr_signature_secret};
+  if ($legacy_secret) {
+    my $expected = 'sha256=' . hmac_sha256_hex($payload, $legacy_secret);
+    return 1 if secure_compare($expected, $received_signature);
+  }
+
+  # Fetch all non-revoked, non-sticky API keys for users in the github-webhook-bot group.
   # Each bot account uses its own Bugzilla API key as the GitHub webhook secret,
   # so individual keys can be revoked without affecting other integrations.
+  # Sticky keys are excluded because they are IP-bound and not appropriate for
+  # webhook use from GitHub's IP ranges.
   my $dbh  = Bugzilla->dbh;
   my $keys = $dbh->selectall_arrayref(
     "SELECT uak.id, uak.api_key
@@ -396,6 +406,7 @@ sub _verify_signature {
        INNER JOIN " . $dbh->quote_identifier('groups') . " g ON g.id = ugm.group_id
       WHERE g.name = 'github-webhook-bot'
         AND uak.revoked = 0
+        AND uak.sticky = 0
         AND ugm.isbless = 0
         AND ugm.grant_type = " . GRANT_DIRECT,
     {Slice => {}}
@@ -404,21 +415,13 @@ sub _verify_signature {
   foreach my $key_row (@{$keys}) {
     my $expected = 'sha256=' . hmac_sha256_hex($payload, $key_row->{api_key});
     if (secure_compare($expected, $received_signature)) {
-      # Update audit trail so admins can see which key authenticated the request
+      # Track key usage so operators can see which key last authenticated a webhook request
       $dbh->do(
         "UPDATE user_api_keys SET last_used = LOCALTIMESTAMP(0), last_used_ip = ? WHERE id = ?",
-        undef, ($self->tx->remote_address // ''), $key_row->{id}
+        undef, $self->tx->remote_address, $key_row->{id}
       );
       return 1;
     }
-  }
-
-  # Fall back to the legacy shared secret for backward compatibility during migration.
-  # Operators should migrate to per-bot API keys and clear this parameter.
-  my $legacy_secret = Bugzilla->params->{github_pr_signature_secret};
-  if ($legacy_secret) {
-    my $expected = 'sha256=' . hmac_sha256_hex($payload, $legacy_secret);
-    return secure_compare($expected, $received_signature) ? 1 : 0;
   }
 
   return 0;

--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -396,7 +396,8 @@ sub _verify_signature {
        INNER JOIN " . $dbh->quote_identifier('groups') . " g ON g.id = ugm.group_id
       WHERE g.name = 'github-webhook-bot'
         AND uak.revoked = 0
-        AND ugm.isbless = 0",
+        AND ugm.isbless = 0
+        AND ugm.grant_type = " . GRANT_DIRECT,
     {Slice => {}}
   );
 
@@ -405,7 +406,7 @@ sub _verify_signature {
     if (secure_compare($expected, $received_signature)) {
       # Update audit trail so admins can see which key authenticated the request
       $dbh->do(
-        "UPDATE user_api_keys SET last_used = NOW(), last_used_ip = ? WHERE id = ?",
+        "UPDATE user_api_keys SET last_used = LOCALTIMESTAMP(0), last_used_ip = ? WHERE id = ?",
         undef, ($self->tx->remote_address // ''), $key_row->{id}
       );
       return 1;

--- a/Bugzilla/API/V1/Github.pm
+++ b/Bugzilla/API/V1/Github.pm
@@ -381,10 +381,46 @@ sub push_comment {
 sub _verify_signature {
   my ($self)             = @_;
   my $payload            = $self->req->body;
-  my $secret             = Bugzilla->params->{github_pr_signature_secret};
   my $received_signature = $self->req->headers->header('X-Hub-Signature-256');
-  my $expected_signature = 'sha256=' . hmac_sha256_hex($payload, $secret);
-  return secure_compare($expected_signature, $received_signature) ? 1 : 0;
+
+  return 0 if !$received_signature;
+
+  # Fetch all non-revoked API keys for users in the github-webhook-bot group.
+  # Each bot account uses its own Bugzilla API key as the GitHub webhook secret,
+  # so individual keys can be revoked without affecting other integrations.
+  my $dbh  = Bugzilla->dbh;
+  my $keys = $dbh->selectall_arrayref(
+    "SELECT uak.id, uak.api_key
+       FROM user_api_keys uak
+       INNER JOIN user_group_map ugm ON ugm.user_id = uak.user_id
+       INNER JOIN " . $dbh->quote_identifier('groups') . " g ON g.id = ugm.group_id
+      WHERE g.name = 'github-webhook-bot'
+        AND uak.revoked = 0
+        AND ugm.isbless = 0",
+    {Slice => {}}
+  );
+
+  foreach my $key_row (@{$keys}) {
+    my $expected = 'sha256=' . hmac_sha256_hex($payload, $key_row->{api_key});
+    if (secure_compare($expected, $received_signature)) {
+      # Update audit trail so admins can see which key authenticated the request
+      $dbh->do(
+        "UPDATE user_api_keys SET last_used = NOW(), last_used_ip = ? WHERE id = ?",
+        undef, ($self->tx->remote_address // ''), $key_row->{id}
+      );
+      return 1;
+    }
+  }
+
+  # Fall back to the legacy shared secret for backward compatibility during migration.
+  # Operators should migrate to per-bot API keys and clear this parameter.
+  my $legacy_secret = Bugzilla->params->{github_pr_signature_secret};
+  if ($legacy_secret) {
+    my $expected = 'sha256=' . hmac_sha256_hex($payload, $legacy_secret);
+    return secure_compare($expected, $received_signature) ? 1 : 0;
+  }
+
+  return 0;
 }
 
 # If the ref matches a certain branch pattern for the repo we are interested

--- a/Bugzilla/Install.pm
+++ b/Bugzilla/Install.pm
@@ -270,7 +270,11 @@ use constant SYSTEM_GROUPS => (
   {
     name        => 'can_see_groups',
     description => 'Can see all groups'
-  }
+  },
+  {
+    name        => 'github-webhook-bot',
+    description => 'Bot accounts whose API keys are valid GitHub webhook secrets',
+  },
 );
 
 use constant DEFAULT_CLASSIFICATION =>

--- a/docs/en/rst/api/core/v1/github.rst
+++ b/docs/en/rst/api/core/v1/github.rst
@@ -12,7 +12,7 @@ and be automatically redirected to the pull request.
 
 * Create or identify a Bugzilla bot account to own this webhook.
 * A BMO admin must add that bot account to the ``github-webhook-bot`` group
-  via the Groups admin UI (``/editusers.cgi``).
+  via the Users admin UI (``/editusers.cgi``).
 * Log in as the bot account and go to Preferences > API Keys.
 * Create a new API key with a descriptive label (e.g.
   ``github-webhook-mozilla-bteam-bmo``). Copy the key value — it will only
@@ -126,7 +126,7 @@ repositories, a Firefox status flag may be set to FIXED.
 
 * Create or identify a Bugzilla bot account to own this webhook.
 * A BMO admin must add that bot account to the ``github-webhook-bot`` group
-  via the Groups admin UI (``/editusers.cgi``).
+  via the Users admin UI (``/editusers.cgi``).
 * Log in as the bot account and go to Preferences > API Keys.
 * Create a new API key with a descriptive label (e.g.
   ``github-webhook-mozilla-bteam-bmo-push``). Copy the key value — it will only

--- a/docs/en/rst/api/core/v1/github.rst
+++ b/docs/en/rst/api/core/v1/github.rst
@@ -10,16 +10,28 @@ and be automatically redirected to the pull request.
 
 **Github Setup Instructions**
 
+* Create or identify a Bugzilla bot account to own this webhook.
+* A BMO admin must add that bot account to the ``github-webhook-bot`` group
+  via the Groups admin UI (``/editusers.cgi``).
+* Log in as the bot account and go to Preferences > API Keys.
+* Create a new API key with a descriptive label (e.g.
+  ``github-webhook-mozilla-bteam-bmo``). Copy the key value — it will only
+  be shown once.
 * From the repository main page, click on the Settings tab.
 * Click on Webhooks from the left side menu.
 * Click on the Add Webhook button near the top right.
 * For the payload url, enter ``https://bugzilla.mozilla.org/rest/github/pull_request``.
 * Choose ``application/json`` for the content type.
-* You will need to enter the signature secret obtained from a BMO admin (DO NOT SHARE).
+* Enter the Bugzilla API key you created above as the webhook secret.
 * Make sure Enable SSL is turned on.
 * Select "Let me select individual events" and only enable changes for "Pull Requests".
 * Make sure at the bottom that "Active" is checked on.
 * Save the webhook.
+
+.. note::
+  If a webhook secret is ever compromised, revoke the affected API key from the
+  bot account's Preferences > API Keys page. Only that single webhook is affected —
+  all other bot accounts' webhooks continue to work without any changes.
 
 .. note::
   Past pull requests will not automatically get a link created in the bug. New pull
@@ -112,17 +124,29 @@ repositories, a Firefox status flag may be set to FIXED.
 
 **Github Setup Instructions**
 
+* Create or identify a Bugzilla bot account to own this webhook.
+* A BMO admin must add that bot account to the ``github-webhook-bot`` group
+  via the Groups admin UI (``/editusers.cgi``).
+* Log in as the bot account and go to Preferences > API Keys.
+* Create a new API key with a descriptive label (e.g.
+  ``github-webhook-mozilla-bteam-bmo-push``). Copy the key value — it will only
+  be shown once.
 * From the repository main page, click on the Settings tab.
 * Click on Webhooks from the left side menu.
 * Click on the Add Webhook button near the top right.
 * For the payload url, enter ``https://bugzilla.mozilla.org/rest/github/push_comment``.
 * Add ``?no-qe-verify=1`` to the URL if you do not want the ``qe-verify`` flag set.
 * Choose ``application/json`` for the content type.
-* You will need to enter the signature secret obtained from a BMO admin (DO NOT SHARE).
+* Enter the Bugzilla API key you created above as the webhook secret.
 * Make sure Enable SSL is turned on.
 * Select "Let me select individual events" and only enable changes for "Pushes".
 * Make sure at the bottom that "Active" is checked on.
 * Save the webhook.
+
+.. note::
+  If a webhook secret is ever compromised, revoke the affected API key from the
+  bot account's Preferences > API Keys page. Only that single webhook is affected —
+  all other bot accounts' webhooks continue to work without any changes.
 
 .. note::
   The API endpoint looks at the commit messages for the bug ID so

--- a/docs/en/rst/api/core/v1/github.rst
+++ b/docs/en/rst/api/core/v1/github.rst
@@ -10,13 +10,21 @@ and be automatically redirected to the pull request.
 
 **Github Setup Instructions**
 
-* Create or identify a Bugzilla bot account to own this webhook.
+* Create or identify a Bugzilla bot account to own this webhook. The bot
+  account should be least-privileged — grant it only the permissions needed
+  for the integration.
 * A BMO admin must add that bot account to the ``github-webhook-bot`` group
   via the Users admin UI (``/editusers.cgi``).
 * Log in as the bot account and go to Preferences > API Keys.
 * Create a new API key with a descriptive label (e.g.
   ``github-webhook-mozilla-bteam-bmo``). Copy the key value — it will only
   be shown once.
+
+.. warning::
+  This API key also grants full access to the Bugzilla REST API as the bot
+  account. Treat it as a credential: store it only in the GitHub webhook
+  secret field and never share it.
+
 * From the repository main page, click on the Settings tab.
 * Click on Webhooks from the left side menu.
 * Click on the Add Webhook button near the top right.
@@ -124,13 +132,21 @@ repositories, a Firefox status flag may be set to FIXED.
 
 **Github Setup Instructions**
 
-* Create or identify a Bugzilla bot account to own this webhook.
+* Create or identify a Bugzilla bot account to own this webhook. The bot
+  account should be least-privileged — grant it only the permissions needed
+  for the integration.
 * A BMO admin must add that bot account to the ``github-webhook-bot`` group
   via the Users admin UI (``/editusers.cgi``).
 * Log in as the bot account and go to Preferences > API Keys.
 * Create a new API key with a descriptive label (e.g.
   ``github-webhook-mozilla-bteam-bmo-push``). Copy the key value — it will only
   be shown once.
+
+.. warning::
+  This API key also grants full access to the Bugzilla REST API as the bot
+  account. Treat it as a credential: store it only in the GitHub webhook
+  secret field and never share it.
+
 * From the repository main page, click on the Settings tab.
 * Click on Webhooks from the left side menu.
 * Click on the Add Webhook button near the top right.

--- a/extensions/PhabBugz/Extension.pm
+++ b/extensions/PhabBugz/Extension.pm
@@ -137,7 +137,7 @@ sub object_before_create {
 
   # Only allow phab-bot to set content type to text/x-phabricator-request
   my $content_type = $params->{mimetype};
-  if ($content_type eq PHAB_CONTENT_TYPE
+  if ($content_type && $content_type eq PHAB_CONTENT_TYPE
     && !Bugzilla->request_cache->{allow_phab_revision_attachment})
   {
     Bugzilla->audit(

--- a/qa/config/selenium_test.conf
+++ b/qa/config/selenium_test.conf
@@ -29,6 +29,8 @@
     'lando_user_api_key'                => 'hqPlbNFAtbGhBC7O68DfMBNE5wu7e18Ssviatizl',
     'pulsebot_user_login'               => 'pulsebot@bmo.tld',
     'pulsebot_user_api_key'             => 'p5vddyKNyvMYpfkmQgXXrutL3Nm2xhb1kBADqF0T',
+    'github_automation_user_login'      => 'github-automation@bmo.tld',
+    'github_automation_user_api_key'    => 'G1tHubAutomationApiKeyForWebhookTesting1',
     'permanent_user_login'              => 'permanent_user@mozilla.test',
     'permanent_user_passwd'             => 'bo6aazeKohch',
     'unprivileged_user_login'           => 'no-privs@mozilla.test',

--- a/qa/t/1_test_bug_edit.t
+++ b/qa/t/1_test_bug_edit.t
@@ -40,7 +40,7 @@ check_page_load($sel, q{http://HOSTNAME/editgroups.cgi});
 $sel->title_is("Edit Groups");
 $sel->click_ok("link=Master");
 check_page_load($sel,
-  q{http://HOSTNAME/editgroups.cgi?action=changeform&group=31});
+  q{http://HOSTNAME/editgroups.cgi?action=changeform&group=32});
 $sel->title_is("Change Group: Master");
 my $group_url = $sel->get_location();
 $group_url =~ /group=(\d+)$/;

--- a/qa/t/rest_github_pull_request.t
+++ b/qa/t/rest_github_pull_request.t
@@ -22,7 +22,7 @@ use Test::More;
 my $config  = get_config();
 my $api_key = $config->{admin_user_api_key};
 my $url     = Bugzilla->localconfig->urlbase;
-my $secret  = 'B1gS3cret!';
+my $secret  = $config->{github_automation_user_api_key};
 
 my $t = Test::Mojo->new();
 

--- a/qa/t/rest_github_push_comment.t
+++ b/qa/t/rest_github_push_comment.t
@@ -20,7 +20,7 @@ use Test::More;
 my $config  = get_config();
 my $api_key = $config->{admin_user_api_key};
 my $url     = Bugzilla->localconfig->urlbase;
-my $secret  = 'B1gS3cret!';
+my $secret  = $config->{github_automation_user_api_key};
 
 my $t = Test::Mojo->new();
 

--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -208,6 +208,7 @@ my @users = (
     login    => 'github-automation@bmo.tld',
     realname => 'BMO Github Automation',
     password => '*',
+    api_key  => 'G1tHubAutomationApiKeyForWebhookTesting1',
   },
 
   map { {login => $_, realname => (split(/@/, $_, 2))[0], password => '*',} }
@@ -578,6 +579,22 @@ foreach my $field (@fields) {
 }
 
 
+##########################################################################
+# Add bot accounts to github-webhook-bot group
+##########################################################################
+print "adding github-automation to github-webhook-bot group...\n";
+my $github_bot_group = Bugzilla::Group->new({name => 'github-webhook-bot'});
+my $github_auto_user = Bugzilla::User->new({name => 'github-automation@bmo.tld'});
+if ($github_bot_group && $github_auto_user) {
+  eval {
+    $dbh->do(
+      'INSERT INTO user_group_map (user_id, group_id, isbless, grant_type)
+            VALUES (?, ?, 0, ?)',
+      undef, $github_auto_user->id, $github_bot_group->id, GRANT_DIRECT
+    );
+  };
+}
+
 # Update default security group settings for new products
 my $default_security_group = Bugzilla::Group->new({name => 'core-security'});
 if ($default_security_group) {
@@ -609,8 +626,7 @@ my %set_params = (
     . '&long_desc_type=substring',
   defaultseverity      => 'normal',
   edit_comments_group  => 'editbugs',
-  github_pr_linking_enabled => 1,
-  github_pr_signature_secret => 'B1gS3cret!',
+  github_pr_linking_enabled   => 1,
   github_push_comment_enabled => 1,
   insidergroup         => 'core-security-release',
   last_change_time_non_bot_skip_list => 'automation@bmo.tld',

--- a/scripts/generate_bmo_data.pl
+++ b/scripts/generate_bmo_data.pl
@@ -586,13 +586,11 @@ print "adding github-automation to github-webhook-bot group...\n";
 my $github_bot_group = Bugzilla::Group->new({name => 'github-webhook-bot'});
 my $github_auto_user = Bugzilla::User->new({name => 'github-automation@bmo.tld'});
 if ($github_bot_group && $github_auto_user) {
-  eval {
-    $dbh->do(
-      'INSERT INTO user_group_map (user_id, group_id, isbless, grant_type)
-            VALUES (?, ?, 0, ?)',
-      undef, $github_auto_user->id, $github_bot_group->id, GRANT_DIRECT
-    );
-  };
+  $dbh->do(
+    'INSERT IGNORE INTO user_group_map (user_id, group_id, isbless, grant_type)
+          VALUES (?, ?, 0, ?)',
+    undef, $github_auto_user->id, $github_bot_group->id, GRANT_DIRECT
+  );
 }
 
 # Update default security group settings for new products

--- a/template/en/default/admin/params/github.html.tmpl
+++ b/template/en/default/admin/params/github.html.tmpl
@@ -29,8 +29,12 @@
     "bug report."
 
   github_pr_signature_secret =>
-    "Shared secret needed for GitHub webhooks to post pull requests to Bugzilla " _
-    "creating an attachment or for pushes to add comments to a bug."
+    "DEPRECATED: Previously used as a shared secret for GitHub webhooks. " _
+    "Migrate to per-bot API keys instead: add bot accounts to the " _
+    "'github-webhook-bot' group, create a Bugzilla API key for each bot " _
+    "under Preferences > API Keys, and use that API key as the GitHub " _
+    "webhook secret. Individual keys can then be revoked without affecting " _
+    "other integrations. Clear this field once all webhooks are migrated."
 
   github_push_comment_enabled =>
     "Enable the ability for Github pushes to add a comment to a related bug report."

--- a/template/en/default/admin/params/github.html.tmpl
+++ b/template/en/default/admin/params/github.html.tmpl
@@ -34,7 +34,9 @@
     "'github-webhook-bot' group, create a Bugzilla API key for each bot " _
     "under Preferences > API Keys, and use that API key as the GitHub " _
     "webhook secret. Individual keys can then be revoked without affecting " _
-    "other integrations. Clear this field once all webhooks are migrated."
+    "other integrations. Clear this field once all webhooks are migrated. " _
+    "Note: Bugzilla API keys also grant full REST API access as the bot " _
+    "account, so the bot should be least-privileged and the key treated as a credential."
 
   github_push_comment_enabled =>
     "Enable the ability for Github pushes to add a comment to a related bug report."


### PR DESCRIPTION
Bug 2023761 - Replace single shared GitHub webhook secret with per-bot API keys

Instead of a single `github_pr_signature_secret` parameter shared across all
GitHub webhook integrations, each bot account now creates a Bugzilla API key
and uses it as their webhook secret. If a key is compromised, only that bot
account needs to be disabled — other integrations are unaffected.

Changes:
- Add `github-webhook-bot` system group; bot accounts in this group have their
  non-revoked API keys accepted as valid webhook secrets
- Rewrite `_verify_signature` in `Bugzilla/API/V1/Github.pm` to query all API
  keys for `github-webhook-bot` group members, with a fallback to the legacy
  `github_pr_signature_secret` parameter for backward compatibility
- Mark `github_pr_signature_secret` as deprecated in the admin UI
- Add API key for `github-automation@bmo.tld` and assign it to the new group
  in `generate_bmo_data.pl`
- Update webservices tests to sign webhook payloads with the bot account API
  key instead of the hardcoded shared secret
- Update setup documentation for both webhook endpoints