### PR TITLE
Bug 2028240 - Pre-check security group when cloning bugs across products

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -4352,6 +4352,25 @@ sub in_group {
   return grep($_->id == $group->id, @{$self->groups_in}) ? 1 : 0;
 }
 
+# Returns extra group names to add when cloning $self into $target_product.
+# If the bug is in its source product's default security group and the target
+# product has a different one, the target group name is returned so the clone
+# stays secure (Bug 2028240).
+sub extra_security_groups_for_clone {
+  my ($self, $target_product) = @_;
+  return () if $self->product_id == $target_product->id;
+  return () unless $target_product->can('default_security_group');
+
+  my @clone_groups = map { $_->name } @{$self->groups_in};
+  my $source_sec = eval { $self->product_obj->default_security_group };
+  return () unless $source_sec && grep { $_ eq $source_sec } @clone_groups;
+
+  my $target_sec = eval { $target_product->default_security_group };
+  return () unless $target_sec && !grep { $_ eq $target_sec } @clone_groups;
+
+  return ($target_sec);
+}
+
 sub user {
   my $self = shift;
   return $self->{'user'} if exists $self->{'user'};

--- a/enter_bug.cgi
+++ b/enter_bug.cgi
@@ -456,6 +456,22 @@ my @groups = $cgi->param('groups');
 if ($cloned_bug) {
   my @clone_groups = map { $_->name } @{$cloned_bug->groups_in};
 
+  # If the cloned bug was in its product's default security group and we're
+  # cloning into a different product, also add the target product's default
+  # security group. This ensures security bugs stay secure when cloned
+  # across products (Bug 2028240).
+  if ($cloned_bug->product_id != $product->id
+    && $product->can('default_security_group'))
+  {
+    my $source_sec_group = eval { $cloned_bug->product_obj->default_security_group };
+    if ($source_sec_group && grep { $_ eq $source_sec_group } @clone_groups) {
+      my $target_sec_group = eval { $product->default_security_group };
+      if ($target_sec_group && !grep { $_ eq $target_sec_group } @clone_groups) {
+        push(@clone_groups, $target_sec_group);
+      }
+    }
+  }
+
   # It doesn't matter if there are duplicate names, since all we check
   # for in the template is whether or not the group is set.
   push(@groups, @clone_groups);

--- a/enter_bug.cgi
+++ b/enter_bug.cgi
@@ -456,21 +456,8 @@ my @groups = $cgi->param('groups');
 if ($cloned_bug) {
   my @clone_groups = map { $_->name } @{$cloned_bug->groups_in};
 
-  # If the cloned bug was in its product's default security group and we're
-  # cloning into a different product, also add the target product's default
-  # security group. This ensures security bugs stay secure when cloned
-  # across products (Bug 2028240).
-  if ($cloned_bug->product_id != $product->id
-    && $product->can('default_security_group'))
-  {
-    my $source_sec_group = eval { $cloned_bug->product_obj->default_security_group };
-    if ($source_sec_group && grep { $_ eq $source_sec_group } @clone_groups) {
-      my $target_sec_group = eval { $product->default_security_group };
-      if ($target_sec_group && !grep { $_ eq $target_sec_group } @clone_groups) {
-        push(@clone_groups, $target_sec_group);
-      }
-    }
-  }
+  # Ensure security bugs stay secure when cloned across products (Bug 2028240).
+  push(@clone_groups, $cloned_bug->extra_security_groups_for_clone($product));
 
   # It doesn't matter if there are duplicate names, since all we check
   # for in the template is whether or not the group is set.

--- a/t/bmo/clone-security-groups.t
+++ b/t/bmo/clone-security-groups.t
@@ -1,0 +1,190 @@
+#!/usr/bin/env perl
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+# Test that cloning a security bug across products preserves security
+# group defaults (Bug 2028240).
+
+use 5.10.1;
+use strict;
+use warnings;
+use lib qw(. lib local/lib/perl5);
+use Test::More;
+
+use Bugzilla;
+use Bugzilla::Constants;
+use Bugzilla::Bug;
+use Bugzilla::Product;
+use Bugzilla::Group;
+BEGIN { Bugzilla->extensions }
+
+Bugzilla->usage_mode(USAGE_MODE_TEST);
+Bugzilla->error_mode(ERROR_MODE_DIE);
+
+# Verify the default_security_group method exists (BMO extension)
+my $test_product = (Bugzilla::Product->get_all)[0];
+plan skip_all => 'BMO extension with default_security_group required'
+  unless $test_product && $test_product->can('default_security_group');
+
+# Set up as admin user
+my $user = Bugzilla::User->check({id => 1});
+Bugzilla->set_user($user);
+
+# Find two products. We need them to have different default security groups
+# to test cross-product cloning. If they share the same group, create a
+# second one.
+my @products = Bugzilla::Product->get_all;
+plan skip_all => 'Need at least 2 products' if @products < 2;
+
+my $prod_a = $products[0];
+my $prod_b = $products[1];
+
+my $sec_group_a = eval { $prod_a->default_security_group };
+my $sec_group_b = eval { $prod_b->default_security_group };
+
+plan skip_all => 'Products need default security groups'
+  unless $sec_group_a && $sec_group_b;
+
+# If both products share the same security group, create a test group
+# and assign it to product B so we can test the cross-product mapping.
+my $created_group;
+if ($sec_group_a eq $sec_group_b) {
+  my $dbh = Bugzilla->dbh;
+  $created_group = Bugzilla::Group->create({
+    name        => 'test-security-clone-' . $$,
+    description => 'Temporary group for clone security test',
+    isbuggroup  => 1,
+  });
+  # Assign to product B
+  $dbh->do(
+    'UPDATE products SET security_group_id = ? WHERE id = ?',
+    undef, $created_group->id, $prod_b->id);
+  # Clear cached value
+  delete $prod_b->{security_group_id};
+  delete $prod_b->{default_security_group_obj};
+
+  $sec_group_b = $prod_b->default_security_group;
+
+  # Make sure the user is in the new group
+  $dbh->do(
+    'INSERT INTO user_group_map (user_id, group_id, isbless, grant_type) VALUES (?, ?, 0, 0)',
+    undef, $user->id, $created_group->id);
+
+  # Also add group to product's group controls so bugs can use it
+  $dbh->do(
+    'INSERT IGNORE INTO group_control_map (group_id, product_id, entry, membercontrol, othercontrol, canedit)
+     VALUES (?, ?, 0, 1, 0, 0)',
+    undef, $created_group->id, $prod_b->id);
+}
+
+isnt($sec_group_a, $sec_group_b,
+  "Test products have different security groups ($sec_group_a vs $sec_group_b)");
+
+# Create a security bug in product A
+my $bug = Bugzilla::Bug->create({
+  short_desc   => 'Test security clone - Bug 2028240',
+  product      => $prod_a->name,
+  component    => $prod_a->components->[0]->name,
+  bug_type     => 'defect',
+  bug_severity => 'normal',
+  op_sys       => 'Unspecified',
+  rep_platform => 'Unspecified',
+  version      => $prod_a->versions->[0]->name,
+  groups       => [$sec_group_a],
+});
+ok($bug->id, "Created security bug " . $bug->id);
+
+my @bug_groups = map { $_->name } @{$bug->groups_in};
+ok((grep { $_ eq $sec_group_a } @bug_groups),
+  "Bug is in source security group ($sec_group_a)");
+
+# ---- Test the clone logic (extracted from enter_bug.cgi) ----
+
+# Simulate cross-product clone: bug from prod_a, target is prod_b
+my @clone_groups = map { $_->name } @{$bug->groups_in};
+
+if ($bug->product_id != $prod_b->id
+  && $prod_b->can('default_security_group'))
+{
+  my $source_sec_group = eval { $bug->product_obj->default_security_group };
+  if ($source_sec_group && grep { $_ eq $source_sec_group } @clone_groups) {
+    my $target_sec_group = eval { $prod_b->default_security_group };
+    if ($target_sec_group && !grep { $_ eq $target_sec_group } @clone_groups) {
+      push(@clone_groups, $target_sec_group);
+    }
+  }
+}
+
+ok((grep { $_ eq $sec_group_b } @clone_groups),
+  "Cross-product clone adds target security group ($sec_group_b)");
+ok((grep { $_ eq $sec_group_a } @clone_groups),
+  "Cross-product clone preserves source security group ($sec_group_a)");
+
+# ---- Same-product clone should not duplicate ----
+
+my @same_groups = map { $_->name } @{$bug->groups_in};
+if ($bug->product_id != $prod_a->id
+  && $prod_a->can('default_security_group'))
+{
+  # This condition is false (same product), so nothing should happen
+  my $source_sec = eval { $bug->product_obj->default_security_group };
+  if ($source_sec && grep { $_ eq $source_sec } @same_groups) {
+    my $target_sec = eval { $prod_a->default_security_group };
+    if ($target_sec && !grep { $_ eq $target_sec } @same_groups) {
+      push(@same_groups, $target_sec);
+    }
+  }
+}
+
+is(scalar(grep { $_ eq $sec_group_a } @same_groups), 1,
+  "Same-product clone doesn't duplicate security group");
+
+# ---- Non-security bug should NOT get security group ----
+
+my $public_bug = Bugzilla::Bug->create({
+  short_desc   => 'Test public clone - Bug 2028240',
+  product      => $prod_a->name,
+  component    => $prod_a->components->[0]->name,
+  bug_type     => 'defect',
+  bug_severity => 'normal',
+  op_sys       => 'Unspecified',
+  rep_platform => 'Unspecified',
+  version      => $prod_a->versions->[0]->name,
+});
+
+my @pub_groups = map { $_->name } @{$public_bug->groups_in};
+if ($public_bug->product_id != $prod_b->id
+  && $prod_b->can('default_security_group'))
+{
+  my $source_sec = eval { $public_bug->product_obj->default_security_group };
+  if ($source_sec && grep { $_ eq $source_sec } @pub_groups) {
+    my $target_sec = eval { $prod_b->default_security_group };
+    if ($target_sec && !grep { $_ eq $target_sec } @pub_groups) {
+      push(@pub_groups, $target_sec);
+    }
+  }
+}
+
+ok(!(grep { $_ eq $sec_group_b } @pub_groups),
+  "Public bug clone does NOT get target security group");
+
+# ---- Cleanup ----
+
+if ($created_group) {
+  my $dbh = Bugzilla->dbh;
+  # Restore product B's original security group
+  my $orig_group = Bugzilla::Group->new({name => $sec_group_a});
+  $dbh->do('UPDATE products SET security_group_id = ? WHERE id = ?',
+    undef, $orig_group->id, $prod_b->id);
+  $dbh->do('DELETE FROM user_group_map WHERE group_id = ?',
+    undef, $created_group->id);
+  $dbh->do('DELETE FROM group_control_map WHERE group_id = ?',
+    undef, $created_group->id);
+  $created_group->remove_from_db();
+}
+
+done_testing();

--- a/t/bmo/clone-security-groups.t
+++ b/t/bmo/clone-security-groups.t
@@ -63,9 +63,8 @@ if ($sec_group_a eq $sec_group_b) {
   $dbh->do(
     'UPDATE products SET security_group_id = ? WHERE id = ?',
     undef, $created_group->id, $prod_b->id);
-  # Clear cached value
-  delete $prod_b->{security_group_id};
-  delete $prod_b->{default_security_group_obj};
+  # Re-fetch product to pick up the new security_group_id
+  $prod_b = Bugzilla::Product->new({id => $prod_b->id});
 
   $sec_group_b = $prod_b->default_security_group;
 
@@ -102,22 +101,11 @@ my @bug_groups = map { $_->name } @{$bug->groups_in};
 ok((grep { $_ eq $sec_group_a } @bug_groups),
   "Bug is in source security group ($sec_group_a)");
 
-# ---- Test the clone logic (extracted from enter_bug.cgi) ----
+# ---- Test the clone logic via Bugzilla::Bug method ----
 
-# Simulate cross-product clone: bug from prod_a, target is prod_b
+# Cross-product clone: bug from prod_a, target is prod_b
 my @clone_groups = map { $_->name } @{$bug->groups_in};
-
-if ($bug->product_id != $prod_b->id
-  && $prod_b->can('default_security_group'))
-{
-  my $source_sec_group = eval { $bug->product_obj->default_security_group };
-  if ($source_sec_group && grep { $_ eq $source_sec_group } @clone_groups) {
-    my $target_sec_group = eval { $prod_b->default_security_group };
-    if ($target_sec_group && !grep { $_ eq $target_sec_group } @clone_groups) {
-      push(@clone_groups, $target_sec_group);
-    }
-  }
-}
+push(@clone_groups, $bug->extra_security_groups_for_clone($prod_b));
 
 ok((grep { $_ eq $sec_group_b } @clone_groups),
   "Cross-product clone adds target security group ($sec_group_b)");
@@ -127,18 +115,7 @@ ok((grep { $_ eq $sec_group_a } @clone_groups),
 # ---- Same-product clone should not duplicate ----
 
 my @same_groups = map { $_->name } @{$bug->groups_in};
-if ($bug->product_id != $prod_a->id
-  && $prod_a->can('default_security_group'))
-{
-  # This condition is false (same product), so nothing should happen
-  my $source_sec = eval { $bug->product_obj->default_security_group };
-  if ($source_sec && grep { $_ eq $source_sec } @same_groups) {
-    my $target_sec = eval { $prod_a->default_security_group };
-    if ($target_sec && !grep { $_ eq $target_sec } @same_groups) {
-      push(@same_groups, $target_sec);
-    }
-  }
-}
+push(@same_groups, $bug->extra_security_groups_for_clone($prod_a));
 
 is(scalar(grep { $_ eq $sec_group_a } @same_groups), 1,
   "Same-product clone doesn't duplicate security group");
@@ -157,17 +134,7 @@ my $public_bug = Bugzilla::Bug->create({
 });
 
 my @pub_groups = map { $_->name } @{$public_bug->groups_in};
-if ($public_bug->product_id != $prod_b->id
-  && $prod_b->can('default_security_group'))
-{
-  my $source_sec = eval { $public_bug->product_obj->default_security_group };
-  if ($source_sec && grep { $_ eq $source_sec } @pub_groups) {
-    my $target_sec = eval { $prod_b->default_security_group };
-    if ($target_sec && !grep { $_ eq $target_sec } @pub_groups) {
-      push(@pub_groups, $target_sec);
-    }
-  }
-}
+push(@pub_groups, $public_bug->extra_security_groups_for_clone($prod_b));
 
 ok(!(grep { $_ eq $sec_group_b } @pub_groups),
   "Public bug clone does NOT get target security group");


### PR DESCRIPTION
When cloning a security bug into a different product (via "New/Clone... as a clone, in a different product"), the source product's security group name doesn't match the target product's security group, so the security checkbox ends up unchecked — creating a public clone of a security-sensitive bug.

**Fix:** When cloning across products, if the source bug had its product's default security group set, also add the target product's default security group to the form defaults. This pre-checks the security checkbox on the clone form.

The fix is guarded so it only activates when:
- Cloning across products (same-product clones are unaffected)
- The source bug actually had its security group set (public bugs don't get a false positive)
- The BMO extension's `default_security_group` method exists (`can()` + `eval` guards)

**Test:** `t/bmo/clone-security-groups.t` covers cross-product security clone, same-product clone (no duplication), and public bug clone (no false positive).