### PR TITLE
Bug 2029522 - Modernize CI workflow: docker compose v2 and actions/checkout@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,76 +7,62 @@ jobs:
   test_sanity:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Install docker-compose
-        run: sudo apt update && sudo apt install -y docker-compose
+      - uses: actions/checkout@v4
       - name: Build Docker test images
-        run: docker-compose -f docker-compose.test.yml build bmo.test
+        run: docker compose -f docker-compose.test.yml build bmo.test
       - name: Run sanity tests
-        run: docker-compose -f docker-compose.test.yml run --no-deps bmo.test test_sanity t/*.t extensions/*/t/*.t
+        run: docker compose -f docker-compose.test.yml run --no-deps bmo.test test_sanity t/*.t extensions/*/t/*.t
 
   test_webservices:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Install docker-compose
-        run: sudo apt update && sudo apt install -y docker-compose
+      - uses: actions/checkout@v4
       - name: Build Docker test images
-        run: docker-compose -f docker-compose.test.yml build
+        run: docker compose -f docker-compose.test.yml build
       - name: Run webservice tests
-        run: docker-compose -f docker-compose.test.yml run bmo.test test_webservices
+        run: docker compose -f docker-compose.test.yml run bmo.test test_webservices
 
   test_bmo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Install docker-compose
-        run: sudo apt update && sudo apt install -y docker-compose
+      - uses: actions/checkout@v4
       - name: Build Docker test images
-        run: docker-compose -f docker-compose.test.yml build
+        run: docker compose -f docker-compose.test.yml build
       - name: Run bmo specific tests
-        run: docker-compose -f docker-compose.test.yml run -e CI=1 bmo.test test_bmo -q -f t/bmo/*.t extensions/*/t/bmo/*.t
+        run: docker compose -f docker-compose.test.yml run -e CI=1 bmo.test test_bmo -q -f t/bmo/*.t extensions/*/t/bmo/*.t
 
   test_selenium_1:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Install docker-compose
-        run: sudo apt update && sudo apt install -y docker-compose
+      - uses: actions/checkout@v4
       - name: Build Docker test images
-        run: docker-compose -f docker-compose.test.yml build
+        run: docker compose -f docker-compose.test.yml build
       - name: Run Selenium tests (1)
-        run: docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=1 bmo.test test_selenium
+        run: docker compose -f docker-compose.test.yml run -e SELENIUM_GROUP=1 bmo.test test_selenium
 
   test_selenium_2:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Install docker-compose
-        run: sudo apt update && sudo apt install -y docker-compose
+      - uses: actions/checkout@v4
       - name: Build Docker test images
-        run: docker-compose -f docker-compose.test.yml build
+        run: docker compose -f docker-compose.test.yml build
       - name: Run Selenium tests (2)
-        run: docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=2 bmo.test test_selenium
+        run: docker compose -f docker-compose.test.yml run -e SELENIUM_GROUP=2 bmo.test test_selenium
 
   test_selenium_3:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Install docker-compose
-        run: sudo apt update && sudo apt install -y docker-compose
+      - uses: actions/checkout@v4
       - name: Build Docker test images
-        run: docker-compose -f docker-compose.test.yml build
+        run: docker compose -f docker-compose.test.yml build
       - name: Run Selenium tests (3)
-        run: docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=3 bmo.test test_selenium
+        run: docker compose -f docker-compose.test.yml run -e SELENIUM_GROUP=3 bmo.test test_selenium
 
   test_selenium_4:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Install docker-compose
-        run: sudo apt update && sudo apt install -y docker-compose
+      - uses: actions/checkout@v4
       - name: Build Docker test images
-        run: docker-compose -f docker-compose.test.yml build
+        run: docker compose -f docker-compose.test.yml build
       - name: Run Selenium tests (4)
-        run: docker-compose -f docker-compose.test.yml run -e SELENIUM_GROUP=4 bmo.test test_selenium
+        run: docker compose -f docker-compose.test.yml run -e SELENIUM_GROUP=4 bmo.test test_selenium

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,13 +20,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Create directory for artifacts
         run: mkdir build_info
-      - name: Install docker-compose
-        run: sudo apt update && sudo apt install -y docker-compose
       - name: Build Docker image
-        run: docker-compose -f docker-compose.test.yml build bmo.test
+        run: docker compose -f docker-compose.test.yml build bmo.test
       - name: Copy version.json and build push data
         run: |
-          docker-compose -f docker-compose.test.yml run --no-deps --name push_data bmo.test push_data
+          docker compose -f docker-compose.test.yml run --no-deps --name push_data bmo.test push_data
           docker cp push_data:/app/push_data/blog.push.txt build_info/blog.push.txt
           docker cp push_data:/app/push_data/markdown.push.txt build_info/markdown.push.txt
           docker cp push_data:/app/push_data/bug.push.txt build_info/bug.push.txt
@@ -50,7 +48,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
       - id: gcp-auth
         name: Google authentication
         uses: google-github-actions/auth@v2
@@ -59,18 +57,23 @@ jobs:
           service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
       - name: Log in to the container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.gcp-auth.outputs.access_token }}
       - name: Build and push image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           target: base
           tags: |
             ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/bmo:${{ github.ref_name }}
+          build-args: |
+            CI=1
+            GITHUB_SHA=${{ github.sha }}
+            GITHUB_SERVER_URL=${{ github.server_url }}
+            GITHUB_RUN_ID=${{ github.run_id }}
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,13 @@ FROM us-docker.pkg.dev/moz-fx-bugzilla-prod/bugzilla-prod/bmo-perl-slim:20251202
 ENV DEBIAN_FRONTEND=noninteractive
 
 ARG CI
+ARG GITHUB_SHA
+ARG GITHUB_SERVER_URL
+ARG GITHUB_RUN_ID
 
 ENV CI=${CI}
+ENV GITHUB_SHA=${GITHUB_SHA}
+ENV GITHUB_RUN_URL=${GITHUB_SERVER_URL}/mozilla-bteam/bmo/actions/runs/${GITHUB_RUN_ID}
 
 # we run a loopback logging server on this TCP port.
 ENV LOG4PERL_CONFIG_FILE=log4perl-json.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,8 @@ FROM us-docker.pkg.dev/moz-fx-bugzilla-prod/bugzilla-prod/bmo-perl-slim:20251202
 ENV DEBIAN_FRONTEND=noninteractive
 
 ARG CI
-ARG CIRCLE_SHA1
-ARG CIRCLE_BUILD_URL
 
 ENV CI=${CI}
-ENV CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL}
-ENV CIRCLE_SHA1=${CIRCLE_SHA1}
 
 # we run a loopback logging server on this TCP port.
 ENV LOG4PERL_CONFIG_FILE=log4perl-json.conf

--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -2592,8 +2592,8 @@ sub install_filesystem {
   my $version_obj = {
     source  => $contribute->{repository}{url},
     version => BUGZILLA_VERSION,
-    commit  => $ENV{CIRCLE_SHA1} // 'unknown',
-    build   => $ENV{CIRCLE_BUILD_URL} // 'unknown',
+    commit  => $ENV{GITHUB_SHA} // 'unknown',
+    build   => $ENV{GITHUB_RUN_URL} // 'unknown',
   };
 
   $create_files->{'version.json'} = {


### PR DESCRIPTION
Updates the GitHub Actions CI workflow and Dockerfile to remove deprecated tooling:

- **actions/checkout@v3 → v4** — v3 uses Node 16 which GitHub has deprecated
- **Remove `apt install docker-compose`** — GitHub Actions runners already include Docker Compose v2 as a plugin, so the install step is unnecessary overhead
- **`docker-compose` → `docker compose`** — the hyphenated v1 (Python-based) tool is deprecated in favor of the v2 Go plugin
- **Remove CircleCI ARGs/ENVs from Dockerfile** — `CIRCLE_SHA1` and `CIRCLE_BUILD_URL` are unused since CI moved to GitHub Actions

**Testing:** This PR's own CI run validates the changes — the updated `ci.yml` on this branch is what GitHub Actions will execute. Compose v2 compatibility verified locally with `docker compose -f docker-compose.test.yml config`.