### PR TITLE
Bug 2029520 - ReadTheDocs webhook has stopped triggering builds since Feb 17

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,9 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.11"
+  jobs:
+    pre_install:
+      - pip install "setuptools>=65.0.0"
 
 sphinx:
   configuration: docs/en/rst/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: "3.11"
   jobs:
     pre_install:
-      - pip install "setuptools>=65.0.0"
+      - python -m pip install "setuptools==82.0.0"
 
 sphinx:
   configuration: docs/en/rst/conf.py


### PR DESCRIPTION
The root cause: ReadTheDocs builds a virtualenv using asdf-managed Python 3.11, then runs pip install --upgrade sphinx as a system-level step (outside the venv). When RTD then runs python -m sphinx, the virtualenv's Sphinx tries to import pkg_resources from setuptools — but setuptools may not be present in the virtualenv yet (modern virtualenv 20.x+ no longer seeds it by default). Even though setuptools==82.0.0 is in requirements.txt, the import failure happens during the RTD-managed sphinx startup phase, before requirements are applied in the correct environment context.

This change adds a pre_install job to .readthedocs.yaml that installs setuptools>=65.0.0 before RTD's own install phase. This ensures pkg_resources (which sphinx/registry.py imports via from pkg_resources import iter_entry_points) is available in the virtualenv before sphinx ever runs.

The existing setuptools==82.0.0 in requirements.txt will then pin it to the exact version afterward — no conflict there.