### PR TITLE
Bug 1934846 - Show both banners if a bug is marked as security sensitive and moco confidential

### DIFF
--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -285,7 +285,8 @@
     background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="rgb(160, 161, 162)" viewBox="0 0 24 24"><path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"/><path fill="none" d="M0 0h24v24H0V0z"/></svg>');
   }
 
-  #private-bug-banner {
+  #private-bug-banner,
+  #confidential-bug-banner {
     --confidential-bug-background-color: #b595f5;
     --security-bug-background-color: #ffaf1a;
   }
@@ -1595,30 +1596,34 @@ input[type="radio"]:checked {
  * Private group banner for confidential and security bugs
  */
 
-:root:has(#private-bug-banner) {
+:root:has(#private-bug-banner),
+:root:has(#confidential-bug-banner) {
   --private-bug-banner-height: 24px;
 }
 
-#private-bug-banner {
+#private-bug-banner,
+#confidential-bug-banner {
   position: fixed;
   inset: var(--global-header-height) 0 auto;
   z-index: calc(var(--global-header-z-index) - 1);
   background-color: var(--confidential-bug-background-color);
   color: #111;
   box-sizing: border-box;
-  height: var(--private-bug-banner-height);
+  height: 24px;
   padding: 4px;
   text-align: center;
   -webkit-user-select: none;
   user-select: none;
 }
 
-#private-bug-banner .icon {
+#private-bug-banner .icon,
+#confidential-bug-banner .icon {
   font-family: var(--icon-font-family);
   vertical-align: text-bottom;
 }
 
-#private-bug-banner .icon::before {
+#private-bug-banner .icon::before,
+#confidential-bug-banner .icon::before {
   content: '\E897';
 }
 
@@ -1626,12 +1631,22 @@ input[type="radio"]:checked {
   background-color: var(--security-bug-background-color);
 }
 
-#private-bug-banner strong {
+#private-bug-banner strong,
+#confidential-bug-banner strong {
   text-transform: uppercase;
 }
 
-#private-bug-banner .groups {
+#private-bug-banner .groups,
+#confidential-bug-banner .groups {
   font-size: var(--font-size-small);
+}
+
+#private-bug-banner + #confidential-bug-banner {
+  inset: calc(var(--global-header-height) + 24px) 0 auto;
+}
+
+:root:has(#private-bug-banner):has(#confidential-bug-banner) {
+  --private-bug-banner-height: 48px;
 }
 
 /**

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -401,22 +401,33 @@
   IF bug && bug.groups_in.size;
     has_banner = 1;
     is_security_bug = 0;
+    is_confidential_bug = 0;
     FOREACH group IN bug.groups_in;
-      is_security_bug = 1 IF group.secure_mail;
+      IF group.secure_mail;
+        is_security_bug = 1;
+      ELSE;
+        is_confidential_bug = 1;
+      END;
     END;
 %]
-  <div id="private-bug-banner" class="[% IF is_security_bug %]security[% ELSE %]confidential[% END %]">
+  [% IF is_security_bug %]
+  <div id="private-bug-banner" class="security">
     <span class="icon" aria-hidden="true"></span>
     <strong>
-      [% IF is_security_bug %]
-        Security Issue - <a href="https://firefox-source-docs.mozilla.org/bug-mgmt/processes/security-approval.html">
-        Approval Process</a>
-      [% ELSE %]
-        Confidential
-      [% END %]
+      Security Issue - <a href="https://firefox-source-docs.mozilla.org/bug-mgmt/processes/security-approval.html">
+      Approval Process</a>
     </strong>
   </div>
-[% END %]
+  [% END %]
+  [% IF is_confidential_bug %]
+  <div id="confidential-bug-banner">
+    <span class="icon" aria-hidden="true"></span>
+    <strong>
+      Confidential
+    </strong>
+  </div>
+  [% END %]
+[% END %] 
 
 <main id="bugzilla-body" tabindex="-1">
 


### PR DESCRIPTION
Previously, when a bug belonged to both a security group (secure_mail) and a confidential group, only one banner was displayed due to an if/else structure in the template. This confused users into thinking a bug wasn't security sensitive when they only saw the confidential banner. This patch separates the detection and rendering of both banners so they display independently:                                                                                                           
                                                                                                                                   
  - Template: loop through groups and set `is_security_bug` and                                                                    
    `is_confidential_bug` flags independently, render two separate banner divs                                                 
  - CSS: add styles for `#confidential-bug-banner`, handle stacking when both 
    banners are present (48px total height), and ensure proper page content offset for all combinations                                                                                                    
                                                                                                                                   
  Fixes: https://bugzilla.mozilla.org/show_bug.cgi?id=1934846
  
  Here is an image displaying what the banners looked like if it belonged to both a security group and confidential group: 
  
  <img width="1118" height="521" alt="Screenshot 2026-04-06 at 6 07 05 PM" src="https://github.com/user-attachments/assets/54b9ba92-7164-4b35-ad5a-2c039bddfb2a" />
  
  
  Here is an image of the banner after the fix: 
  
<img width="1117" height="523" alt="Screenshot 2026-04-06 at 6 08 22 PM" src="https://github.com/user-attachments/assets/ba237c94-6535-428c-a68e-f7bd430a85cc" />

Additionally here are two images, showing the banner if just one or the other (Security group and confidential group) are selected after the fix:

<img width="1115" height="519" alt="Screenshot 2026-04-06 at 6 09 26 PM" src="https://github.com/user-attachments/assets/85256e0d-56bd-49df-83da-a9c0c63aa031" />

<img width="1456" height="680" alt="Screenshot 2026-04-06 at 6 12 23 PM" src="https://github.com/user-attachments/assets/e552bb1f-a22d-4e69-a30a-e8e2dc8fb22c" />


  