### PR TITLE
Bug 2030581 - Pass is_markdown when adding comment via attachment update REST API

### DIFF
--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -1228,8 +1228,11 @@ sub add_comment {
     {
       isprivate => $params->{is_private},
       work_time => $params->{work_time},
-      is_markdown =>
-        ( defined $params->{is_markdown} ? $params->{is_markdown} : 0 )
+      is_markdown => (
+        defined $params->{is_markdown}
+          ? ($params->{is_markdown} ? 1 : 0)
+          : (Bugzilla->params->{use_markdown} ? 1 : 0)
+      )
     }
   );
 

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -1006,11 +1006,17 @@ sub add_attachment {
   $dbh->bz_start_transaction();
   my $timestamp = $dbh->selectrow_array('SELECT LOCALTIMESTAMP(0)');
 
-  my $flags     = delete $params->{flags};
-  my $comment   = delete $params->{comment};
-  my $bug_flags = delete $params->{bug_flags};
+  my $flags       = delete $params->{flags};
+  my $comment     = delete $params->{comment};
+  my $is_markdown = delete $params->{is_markdown};
+  my $bug_flags   = delete $params->{bug_flags};
 
   $comment = $comment ? trim($comment) : '';
+
+  # Default to the system use_markdown setting, matching attachment.cgi.
+  if (!defined $is_markdown) {
+    $is_markdown = Bugzilla->params->{use_markdown} ? 1 : 0;
+  }
 
   foreach my $bug (@bugs) {
     my $attachment = Bugzilla::Attachment->create({
@@ -1035,9 +1041,10 @@ sub add_attachment {
     $bug->add_comment(
       $comment,
       {
-        isprivate  => $attachment->isprivate,
-        type       => CMT_ATTACHMENT_CREATED,
-        extra_data => $attachment->id
+        isprivate   => $attachment->isprivate,
+        type        => CMT_ATTACHMENT_CREATED,
+        extra_data  => $attachment->id,
+        is_markdown => ($is_markdown ? 1 : 0),
       }
     );
 

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -1088,11 +1088,17 @@ sub update_attachment {
     $bugs{$bug->id} = $bug;
   }
 
-  my $flags     = delete $params->{flags};
-  my $comment   = delete $params->{comment};
-  my $bug_flags = delete $params->{bug_flags};
+  my $flags       = delete $params->{flags};
+  my $comment     = delete $params->{comment};
+  my $is_markdown = delete $params->{is_markdown};
+  my $bug_flags   = delete $params->{bug_flags};
 
   $comment = $comment ? trim($comment) : '';
+
+  # Default to the system use_markdown setting, matching attachment.cgi.
+  if (!defined $is_markdown) {
+    $is_markdown = Bugzilla->params->{use_markdown} ? 1 : 0;
+  }
 
   # Update the values
   foreach my $attachment (@attachments) {
@@ -1138,9 +1144,10 @@ sub update_attachment {
       $bug->add_comment(
         $comment,
         {
-          isprivate  => $attachment->isprivate,
-          type       => CMT_ATTACHMENT_UPDATED,
-          extra_data => $attachment->id
+          isprivate   => $attachment->isprivate,
+          type        => CMT_ATTACHMENT_UPDATED,
+          extra_data  => $attachment->id,
+          is_markdown => $is_markdown,
         }
       );
     }

--- a/Bugzilla/WebService/Bug.pm
+++ b/Bugzilla/WebService/Bug.pm
@@ -1147,7 +1147,7 @@ sub update_attachment {
           isprivate   => $attachment->isprivate,
           type        => CMT_ATTACHMENT_UPDATED,
           extra_data  => $attachment->id,
-          is_markdown => $is_markdown,
+          is_markdown => ($is_markdown ? 1 : 0),
         }
       );
     }

--- a/docs/en/rst/api/core/v1/attachment.rst
+++ b/docs/en/rst/api/core/v1/attachment.rst
@@ -305,6 +305,8 @@ file_name     string   The "file name" that will be displayed in the UI for this
                        attachment.
 summary       string   A short string describing the attachment.
 comment       string   An optional comment to add to the attachment's bug.
+is_markdown   boolean  If ``true``, the ``comment`` will be rendered as Markdown.
+                       Defaults to the system ``use_markdown`` setting.
 content_type  string   The MIME type of the attachment, like ``text/plain``
                        or ``image/png``.
 is_patch      boolean  ``true`` if Bugzilla should treat this attachment as a

--- a/docs/en/rst/api/core/v1/attachment.rst
+++ b/docs/en/rst/api/core/v1/attachment.rst
@@ -187,6 +187,9 @@ name              type     description
 **content_type**  string   The MIME type of the attachment, like ``text/plain``
                            or ``image/png``.
 comment           string   A comment to add along with this attachment.
+is_markdown       boolean  If ``true``, the ``comment`` will be rendered as
+                           Markdown. Defaults to the system ``use_markdown``
+                           setting.
 is_patch          boolean  ``true`` if Bugzilla should treat this attachment as a
                            patch. If you specify this, you do not need to specify
                            a ``content_type``. The ``content_type`` of the

--- a/docs/en/rst/api/core/v1/comment.rst
+++ b/docs/en/rst/api/core/v1/comment.rst
@@ -170,7 +170,7 @@ ids          array    List of integer bug IDs to add the comment to.
 is_private   boolean  If set to true, the comment is private, otherwise it is
                       assumed to be public.
 is_markdown  boolean  If true, the comment will be rendered as markdown.
-                      (default: false)
+                      Defaults to the system ``use_markdown`` setting.
 work_time    double   Adds this many hours to the "Hours Worked" on the bug.
                       If you are not in the time tracking group, this value will
                       be ignored.


### PR DESCRIPTION
When using PUT /rest/bug/attachment/{id} with a 'comment' field, the resulting comment is always rendered as plain text, even when the system has use_markdown enabled.

**Root cause:** the update_attachment method in Bugzilla/WebService/Bug.pm does not pass is_markdown to $bug->add_comment(). The web UI path in attachment.cgi correctly sets is_markdown based on Bugzilla->params->{use_markdown}.

This means there is no way via the REST API to get a Markdown-rendered comment when updating an attachment (e.g. for sec-approval requests where both the questionnaire comment and the sec-approval? flag need to appear as a single entry).

**Fix:** accept an optional is_markdown parameter in update_attachment, default to the system use_markdown setting when not provided (matching attachment.cgi behavior), and pass it through to $bug->add_comment().

**Steps to reproduce:**
1. PUT /rest/bug/attachment/{id} with {"comment": "### Heading\n* **bold**: text", "flags": [...]}
2. The comment is stored and displayed as plain text, not Markdown

**Expected:** The comment should respect is_markdown (or default to the system use_markdown setting).

**Actual:** is_markdown is never passed to add_comment(); passing it as a top-level parameter causes: "The requested method 'Bugzilla::Attachment::set_is_markdown' was not found."

### What this patch does

The update_attachment WebService method does not pass is_markdown to add_comment(), so comments added through PUT /rest/bug/attachment/{id} are always rendered as plain text. The web UI path in attachment.cgi correctly sets is_markdown based on the system use_markdown parameter.

This patch:
- Accepts an optional is_markdown parameter in update_attachment
- Defaults to the system use_markdown setting when not provided (matching attachment.cgi behavior)
- Passes it through to $bug->add_comment()
- Documents the new parameter in the REST API docs