### PR TITLE
Bug 2018260 - "Fields You Can Search On" is blocking people from making it through quicksearch.html doc

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -64,20 +64,6 @@ use Bugzilla::Extension::BMO::Constants;
 use Bugzilla::Extension::BMO::FakeBug;
 use Bugzilla::Extension::BMO::Data;
 
-use constant PRODUCT_CHANNELS => {
-  'firefox' => {
-    'nightly' => {label => 'Nightly', json_key => 'FIREFOX_NIGHTLY'},
-    'beta'    => {label => 'Beta',    json_key => 'LATEST_FIREFOX_DEVEL_VERSION'},
-    'release' => {label => 'Release', json_key => 'LATEST_FIREFOX_VERSION'},
-    'esr'     => {label => 'ESR',     json_key => 'FIREFOX_ESR'},
-  },
-  'thunderbird' => {
-    'nightly' => {label => 'Daily',   json_key => 'LATEST_THUNDERBIRD_NIGHTLY_VERSION'},
-    'beta'    => {label => 'Beta',    json_key => 'LATEST_THUNDERBIRD_DEVEL_VERSION'},
-    'release' => {label => 'Release', json_key => 'LATEST_THUNDERBIRD_VERSION'},
-  },
-};
-
 our $VERSION = '0.1';
 
 #
@@ -2765,24 +2751,19 @@ sub search_params_to_data_structure {
   my ($self, $args) = @_;
   my $params = $args->{search}->_params;
 
-  # Get the Firefox channel list and put it a regex pattern
-  # Thunderbird doesn't have ESR now but it won't be practically a problem
-  my $channels_re = join('|', keys %{PRODUCT_CHANNELS->{'firefox'}});
-  my $flag_re     = qr/^cf_(status|tracking)_(firefox|thunderbird)_($channels_re)$/;
-
   # Replace pronouns for Firefox/Thunderbird Status/Tracking Flags, for example,
   # cf_tracking_firefox_nightly -> cf_tracking_firefox68
   # cf_tracking_firefox_esr     -> cf_tracking_firefox_esr60
   for my $key (keys %$params) {
     # Replace keys
-    if ($key =~ $flag_re) {
+    if ($key =~ $flag_pronoun_re) {
       my ($canonical, $alias) = _get_search_param_name($1, $2, $3);
       ThrowUserError('product_version_pronouns_unavailable') unless $canonical;
       $params->{$canonical} = delete $params->{$key};
     }
 
     # Replace values (custom search)
-    if ($params->{$key} =~ $flag_re) {
+    if ($params->{$key} =~ $flag_pronoun_re) {
       my ($canonical, $alias) = _get_search_param_name($1, $2, $3);
       ThrowUserError('product_version_pronouns_unavailable') unless $canonical;
       $params->{$key} = $canonical;

--- a/extensions/BMO/lib/Data.pm
+++ b/extensions/BMO/lib/Data.pm
@@ -21,7 +21,30 @@ our @EXPORT = qw( $cf_visible_in_products
   %create_bug_formats
   @default_named_queries
   %autodetect_attach_urls
-  @triage_keyword_products );
+  @triage_keyword_products
+  PRODUCT_CHANNELS
+  $flag_pronoun_re );
+
+use constant PRODUCT_CHANNELS => {
+  'firefox' => {
+    'nightly' => {label => 'Nightly', json_key => 'FIREFOX_NIGHTLY'},
+    'beta'    => {label => 'Beta',    json_key => 'LATEST_FIREFOX_DEVEL_VERSION'},
+    'release' => {label => 'Release', json_key => 'LATEST_FIREFOX_VERSION'},
+    'esr'     => {label => 'ESR',     json_key => 'FIREFOX_ESR'},
+  },
+  'thunderbird' => {
+    'nightly' => {label => 'Daily',   json_key => 'LATEST_THUNDERBIRD_NIGHTLY_VERSION'},
+    'beta'    => {label => 'Beta',    json_key => 'LATEST_THUNDERBIRD_DEVEL_VERSION'},
+    'release' => {label => 'Release', json_key => 'LATEST_THUNDERBIRD_VERSION'},
+  },
+};
+
+our $flag_pronoun_re = do {
+  # Get the Firefox channel list and build a regex pattern. Thunderbird doesn’t
+  # have ESR now but it won't be practically a problem.
+  my $channels_re = join('|', keys %{PRODUCT_CHANNELS->{'firefox'}});
+  qr/^cf_(status|tracking)_(firefox|thunderbird)_($channels_re)$/;
+};
 
 # Creating an attachment whose contents is a URL matching one of these regexes
 # will result in the user being redirected to that URL when viewing the

--- a/extensions/TrackingFlags/Extension.pm
+++ b/extensions/TrackingFlags/Extension.pm
@@ -90,9 +90,12 @@ sub page_before_template {
         $quicksearch_extra_field_names{$key} = {
           nicknames => $field_names->{$key}->{nicknames},
           db_field  => $db_field,
-          # A field is active if it’s an alias like `tracking-firefox-release` or if it’s a real
-          # field that’s active in the database
-          active    => $db_field =~ /_[a-z]+$/ || $active_flag_names{$db_field} ? 1 : 0,
+          # Check if the field is active by looking for a corresponding active tracking flag, e.g.
+          # `cf_tracking_firefox135`, or if it's one of the channel pronouns like
+          # `cf_tracking_firefox_release`, which are created by the BMO extension in
+          # install_update_db but not stored in the tracking flags table. The `$flag_pronoun_re`
+          # regex matches these pronoun fields precisely.
+          active    => ($active_flag_names{$db_field} || $db_field =~ $flag_pronoun_re) ? 1 : 0,
         };
 
         delete $field_names->{$key};

--- a/extensions/TrackingFlags/Extension.pm
+++ b/extensions/TrackingFlags/Extension.pm
@@ -76,6 +76,31 @@ sub page_before_template {
       {group => 'admin', action => 'access', object => 'administrative_pages'});
     admin_edit($vars);
   }
+  elsif ($page eq 'quicksearch.html') {
+    my $field_names = $vars->{'quicksearch_field_names'};
+    my %quicksearch_extra_field_names;
+    my $active_flags = Bugzilla::Extension::TrackingFlags::Flag->match({is_active => 1});
+    my %active_flag_names = map { $_->{name} => 1 } @$active_flags;
+
+    # Move cf_tracking_* and cf_status_* into a separate var with active flag info
+    foreach my $key (keys %$field_names) {
+      my $db_field = $field_names->{$key}->{db_field};
+
+      if ($db_field =~ /^cf_(tracking|status)_/) {
+        $quicksearch_extra_field_names{$key} = {
+          nicknames => $field_names->{$key}->{nicknames},
+          db_field  => $db_field,
+          # A field is active if it’s an alias like `tracking-firefox-release` or if it’s a real
+          # field that’s active in the database
+          active    => $db_field =~ /_[a-z]+$/ || $active_flag_names{$db_field} ? 1 : 0,
+        };
+
+        delete $field_names->{$key};
+      }
+    }
+
+    $vars->{'quicksearch_extra_field_names'} = \%quicksearch_extra_field_names;
+  }
 }
 
 sub template_before_process {

--- a/page.cgi
+++ b/page.cgi
@@ -23,6 +23,7 @@ use Bugzilla;
 use Bugzilla::Error;
 use Bugzilla::Hook;
 use Bugzilla::Search::Quicksearch;
+use Bugzilla::Util qw(template_var);
 
 ###############
 # Subroutines #
@@ -31,14 +32,17 @@ use Bugzilla::Search::Quicksearch;
 # For quicksearch.html.
 sub quicksearch_field_names {
   my $fields = Bugzilla::Search::Quicksearch->FIELD_MAP;
+  my $field_descs = template_var('field_descs');
   my %fields_reverse;
 
   # Put longer names before shorter names.
   my @nicknames = sort { length($b) <=> length($a) } (keys %$fields);
   foreach my $nickname (@nicknames) {
     my $db_field = $fields->{$nickname};
-    $fields_reverse{$db_field} ||= [];
-    push(@{$fields_reverse{$db_field}}, $nickname);
+    my $key = $field_descs->{$db_field} || $db_field;
+
+    $fields_reverse{$key} ||= {nicknames => [], db_field => $db_field, active => 1};
+    push(@{$fields_reverse{$key}->{nicknames}}, $nickname);
   }
   return \%fields_reverse;
 }
@@ -70,7 +74,12 @@ if ($id) {
     ThrowCodeError("bad_page_cgi_id");
   }
 
-  my %vars = (quicksearch_field_names => \&quicksearch_field_names,);
+  my %vars;
+
+  if ($id eq 'quicksearch.html') {
+    $vars{quicksearch_field_names} = quicksearch_field_names();
+  }
+
   Bugzilla::Hook::process('page_before_template',
     {page_id => $id, vars => \%vars});
 

--- a/skins/standard/page.css
+++ b/skins/standard/page.css
@@ -64,21 +64,11 @@
 }
 
 .qs_fields th {
-  padding: 0 .25em;
-}
-
-.qs_fields th.field_nickname {
   text-align: left;
 }
 
 .qs_fields td {
-  padding: .25em;
-  border-top: 1px solid var(--grid-border-color);
   line-height: var(--line-height-comfortable);
-}
-
-.qs_fields .field_name {
-  white-space: nowrap;
 }
 
 /***************/

--- a/skins/standard/page.css
+++ b/skins/standard/page.css
@@ -59,7 +59,7 @@
   flex: auto;
 }
 
-.qs_fields tr[data-active="0"] {
+.qs_fields tr[data-active="false"] {
   opacity: 0.5;
 }
 

--- a/skins/standard/page.css
+++ b/skins/standard/page.css
@@ -46,6 +46,23 @@
   margin-top: 1ex;
 }
 
+.qs_field_table_wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 16px;
+  overflow-y: auto;
+  max-height: 500px;
+}
+
+.qs_fields {
+  flex: auto;
+}
+
+.qs_fields tr[data-active="0"] {
+  opacity: 0.5;
+}
+
 .qs_fields th {
   padding: 0 .25em;
 }

--- a/skins/standard/page.css
+++ b/skins/standard/page.css
@@ -59,7 +59,7 @@
   flex: auto;
 }
 
-.qs_fields tr[data-active="false"] {
+.qs_fields tr.inactive {
   opacity: 0.5;
 }
 

--- a/template/en/default/pages/quicksearch.html.tmpl
+++ b/template/en/default/pages/quicksearch.html.tmpl
@@ -158,33 +158,61 @@
     standard field names always take precedence.</p>
 [% END %]
 
-[% SET field_table = {} %]
-[% FOREACH field = quicksearch_field_names.keys %]
-  [% description = field_descs.$field %]
-  [% field_table.$description = quicksearch_field_names.${field} %]
+[% IF quicksearch_extra_field_names %]
+  <p>
+    <label>
+      <input type="checkbox" id="qs_show_inactive_fields" />
+      Show Inactive Fields (You can still search on these fields)
+    </label>
+  </p>
+
+  <script [% script_nonce FILTER none %]>
+    window.addEventListener('DOMContentLoaded', () => {
+      const $checkbox = document.getElementById('qs_show_inactive_fields');
+      const inactiveFields = document.querySelectorAll('.qs_fields tr[data-active="0"]');
+
+      $checkbox.checked = false;
+      $checkbox.addEventListener('change', () => {
+        const showInactive = $checkbox.checked;
+
+        inactiveFields.forEach((row) => {
+          row.hidden = !showInactive;
+        });
+      });
+    });
+  </script>
 [% END %]
 
-
-<table cellspacing="0" cellpadding="0" border="0" class="qs_fields">
-  <thead>
-    <tr>
-      <th class="field_name">Field</th>
-      <th class="field_nickname">Field Name(s) For Search</th>
-    </tr>
-  </thead>
-  <tbody>
-    [% FOREACH desc = field_table.keys.sort %]
+[% BLOCK field_table %]
+  <table cellspacing="0" cellpadding="0" border="0" class="qs_fields">
+    <thead>
       <tr>
-        <td class="field_name">[% desc FILTER html %]</td>
-        <td class="field_nickname">
-          [% FOREACH nickname = field_table.$desc %]
-            <kbd>[% nickname FILTER html %]</kbd>
-            [% ",&nbsp; " UNLESS loop.last %]
-          [% END %]
+        <th class="field_name">Field</th>
+        <th class="field_nickname">Field Names For Search</th>
       </tr>
-    [% END %]
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      [% FOREACH desc = table.keys.sort %]
+        <tr data-active="[% table.$desc.active %]" [% IF !table.$desc.active %]hidden[% END %]>
+          <td class="field_name">[% desc FILTER html %]</td>
+          <td class="field_nickname">
+            [% FOREACH nickname = table.$desc.nicknames %]
+              <code>[% nickname FILTER html %]</code>
+              [% "<br>" UNLESS loop.last %]
+            [% END %]
+          </td>
+        </tr>
+      [% END %]
+    </tbody>
+  </table>
+[% END %]
+
+<div class="qs_field_table_wrapper">
+  [% INCLUDE field_table table = quicksearch_field_names %]
+  [% IF quicksearch_extra_field_names %]
+    [% INCLUDE field_table table = quicksearch_extra_field_names %]
+  [% END %]
+</div>
 
 <h2 id="advanced_features">Advanced Features</h2>
 

--- a/template/en/default/pages/quicksearch.html.tmpl
+++ b/template/en/default/pages/quicksearch.html.tmpl
@@ -169,7 +169,7 @@
   <script [% script_nonce FILTER none %]>
     window.addEventListener('DOMContentLoaded', () => {
       const $checkbox = document.getElementById('qs_show_inactive_fields');
-      const inactiveFields = document.querySelectorAll('.qs_fields tr[data-active="false"]');
+      const inactiveFields = document.querySelectorAll('.qs_fields tr.inactive');
 
       $checkbox.checked = false;
       $checkbox.addEventListener('change', () => {
@@ -193,9 +193,10 @@
     </thead>
     <tbody>
       [% FOREACH desc = table.keys.sort %]
-        <tr data-active="[% table.$desc.active ? 'true' : 'false' %]"
-            [% IF !table.$desc.active %]hidden[% END %]>
-          <td class="field_name">[% desc FILTER html %]</td>
+        <tr [% IF !table.$desc.active %]class="inactive" hidden[% END %]>
+          <td class="field_name">
+            [% desc FILTER html %] [%+ IF !table.$desc.active %](inactive)[% END %]
+          </td>
           <td class="field_nickname">
             [% FOREACH nickname = table.$desc.nicknames %]
               <code>[% nickname FILTER html %]</code>

--- a/template/en/default/pages/quicksearch.html.tmpl
+++ b/template/en/default/pages/quicksearch.html.tmpl
@@ -169,7 +169,7 @@
   <script [% script_nonce FILTER none %]>
     window.addEventListener('DOMContentLoaded', () => {
       const $checkbox = document.getElementById('qs_show_inactive_fields');
-      const inactiveFields = document.querySelectorAll('.qs_fields tr[data-active="0"]');
+      const inactiveFields = document.querySelectorAll('.qs_fields tr[data-active="false"]');
 
       $checkbox.checked = false;
       $checkbox.addEventListener('change', () => {
@@ -193,7 +193,8 @@
     </thead>
     <tbody>
       [% FOREACH desc = table.keys.sort %]
-        <tr data-active="[% table.$desc.active %]" [% IF !table.$desc.active %]hidden[% END %]>
+        <tr data-active="[% table.$desc.active ? 'true' : 'false' %]"
+            [% IF !table.$desc.active %]hidden[% END %]>
           <td class="field_name">[% desc FILTER html %]</td>
           <td class="field_nickname">
             [% FOREACH nickname = table.$desc.nicknames %]

--- a/template/en/default/pages/quicksearch.html.tmpl
+++ b/template/en/default/pages/quicksearch.html.tmpl
@@ -184,7 +184,7 @@
 [% END %]
 
 [% BLOCK field_table %]
-  <table cellspacing="0" cellpadding="0" border="0" class="qs_fields">
+  <table cellspacing="0" cellpadding="0" border="0" class="standard qs_fields">
     <thead>
       <tr>
         <th class="field_name">Field</th>
@@ -323,7 +323,7 @@
   specific fields, there are certain characters or words that you can
   use as a "shortcut" for searching certain fields:</p>
 
-<table cellspacing="0" cellpadding="0" border="0" class="qs_fields">
+<table cellspacing="0" cellpadding="0" border="0" class="standard qs_fields">
   <thead>
     <tr>
       <th class="field_name">Field</th>


### PR DESCRIPTION
[Bug 2018260 - "Fields You Can Search On" is blocking people from making it through quicksearch.html doc](https://bugzilla.mozilla.org/show_bug.cgi?id=2018260)

Revised version of #2564.

- Include an active flag in the page data rather than modifying `quicksearch_map`
- Hide inactive fields by default
- Add a checkbox to toggle inactive fields
- Use the standard table styles