### PR TITLE
Bug 2028222 - Pasting multi-line text after selecting multi-line text does not overwrite, but applies markup for link

### DIFF
--- a/js/text-editor.js
+++ b/js/text-editor.js
@@ -296,7 +296,7 @@ Bugzilla.TextEditor = class TextEditor {
   textareaOnPaste(event) {
     const data = event.clipboardData?.getData('text');
 
-    if (data.match(/^https?:\/\//) && URL.canParse(data)) {
+    if (/^https?:\/\/\S+$/.test(data) && URL.canParse(data)) {
       const { start, end, beforeText, selectedText, afterText } = this.getSelection();
 
       if (selectedText) {


### PR DESCRIPTION
[Bug 2028222 - Pasting multi-line text after selecting multi-line text does not overwrite, but applies markup for link](https://bugzilla.mozilla.org/show_bug.cgi?id=2028222)

Adjust the regex to only match single-line URLs.