### PR TITLE
Bug 2012634 - "Phabricator Revisions" table overflows on X axis on mobile

### DIFF
--- a/extensions/PhabBugz/web/style/phabricator.css
+++ b/extensions/PhabBugz/web/style/phabricator.css
@@ -164,6 +164,7 @@ span[class^="review-status-icon-"]::before {
  */
 
 #module-phabricator-revisions .module-content {
+  overflow-x: auto;
   padding: 0;
 }
 


### PR DESCRIPTION
[Bug 2012634 - "Phabricator Revisions" table overflows on X axis on mobile](https://bugzilla.mozilla.org/show_bug.cgi?id=2012634)

Modify the style so that the module can be scrolled horizontally rather than overflowing.