### PR TITLE
Bug 2031520 - Missing space in "Throw away my changes, andrevisit bug NNN" message (when marking a bug as a duplicate of a hidden bug)

### DIFF
--- a/template/en/default/bug/process/confirm-duplicate.html.tmpl
+++ b/template/en/default/bug/process/confirm-duplicate.html.tmpl
@@ -64,7 +64,7 @@
 </p>
 <p>
   Throw away my changes, and
-  [% "revisit $terms.bug $duplicate_bug_id" FILTER bug_link(duplicate_bug_id) FILTER none %]
+  [%+ "revisit $terms.bug $duplicate_bug_id" FILTER bug_link(duplicate_bug_id) FILTER none %]
 </p>
 <p>
   <input type="submit" id="process" value="Submit">


### PR DESCRIPTION
[Bug 2031520 - Missing space in "Throw away my changes, andrevisit bug NNN" message (when marking a bug as a duplicate of a hidden bug)](https://bugzilla.mozilla.org/show_bug.cgi?id=2031520)

Add `+` like this:

https://github.com/mozilla-bteam/bmo/blob/a2e4064782d385b35ca3226683ef6d85b43bcf20/template/en/default/bug/process/midair.html.tmpl#L106-L107