### PR TITLE
Bug 1976263 - Cookie banner hides cookie page

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -244,6 +244,11 @@ const scroll_element_into_view = ($target, complete) => {
 }
 
 const openBanner = () => {
+  // If the banner element is not present, do not attempt to open the banner
+  if (!document.querySelector('#moz-consent-banner')) {
+    return;
+  }
+
   // Bind click event listeners for banner buttons
   document
     .getElementById("moz-consent-banner-button-accept")
@@ -296,12 +301,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
   // Mozilla Consent Banner
   // Bind open and close events before calling init().
-  if (
-    BUGZILLA.config.cookie_consent_enabled &&
-    BUGZILLA.config.cookie_consent_required &&
-    // Don’t show the banner on the cookie settings page to avoid hiding the content
-    !window.location.href.endsWith('/page.cgi?id=cookies.html')
-  ) {
+  if (BUGZILLA.config.cookie_consent_enabled && BUGZILLA.config.cookie_consent_required) {
     window.addEventListener('mozConsentOpen', openBanner, false);
     window.addEventListener('mozConsentReset', openBanner, false);
     window.addEventListener('mozConsentClose', closeBanner, false);

--- a/js/global.js
+++ b/js/global.js
@@ -296,7 +296,12 @@ window.addEventListener('DOMContentLoaded', () => {
 
   // Mozilla Consent Banner
   // Bind open and close events before calling init().
-  if (BUGZILLA.config.cookie_consent_enabled && BUGZILLA.config.cookie_consent_required) {
+  if (
+    BUGZILLA.config.cookie_consent_enabled &&
+    BUGZILLA.config.cookie_consent_required &&
+    // Don’t show the banner on the cookie settings page to avoid hiding the content
+    !window.location.href.endsWith('/page.cgi?id=cookies.html')
+  ) {
     window.addEventListener('mozConsentOpen', openBanner, false);
     window.addEventListener('mozConsentReset', openBanner, false);
     window.addEventListener('mozConsentClose', closeBanner, false);

--- a/page.cgi
+++ b/page.cgi
@@ -80,6 +80,10 @@ if ($id) {
     $vars{quicksearch_field_names} = quicksearch_field_names();
   }
 
+  if ($id eq 'cookies.html') {
+    $vars{cookie_consent_hidden} = 1;
+  }
+
   Bugzilla::Hook::process('page_before_template',
     {page_id => $id, vars => \%vars});
 

--- a/qa/t/1_test_cookie_consent.t
+++ b/qa/t/1_test_cookie_consent.t
@@ -21,7 +21,13 @@ log_in($sel, $config, 'admin');
 set_parameters($sel,
   {'Administrative Policies' => {'cookie_consent_enabled-on' => undef}});
 
+# Verify that the cookie banner is hidden on the cookie settings page
+$sel->open_ok('/page.cgi?id=cookies.html', 'Go to cookie settings page');
+ok(!$sel->is_element_present('moz-consent-banner'),
+  'Cookie banner hidden on cookie settings page');
+
 # Accept all cookies for admin user
+$sel->open_ok('/home', 'Go to home page');
 $sel->click_ok('moz-consent-banner-button-accept');
 
 # Make sure that a 'moz-consent-pref' cookie was set to yes

--- a/qa/t/1_test_cookie_consent.t
+++ b/qa/t/1_test_cookie_consent.t
@@ -23,7 +23,7 @@ set_parameters($sel,
 
 # Verify that the cookie banner is hidden on the cookie settings page
 $sel->open_ok('/page.cgi?id=cookies.html', 'Go to cookie settings page');
-ok(!$sel->click_ok('moz-consent-banner-button-accept'),
+ok(!$sel->is_element_present('moz-consent-banner'),
   'Cookie banner hidden on cookie settings page');
 
 # Accept all cookies for admin user

--- a/qa/t/1_test_cookie_consent.t
+++ b/qa/t/1_test_cookie_consent.t
@@ -23,7 +23,7 @@ set_parameters($sel,
 
 # Verify that the cookie banner is hidden on the cookie settings page
 $sel->open_ok('/page.cgi?id=cookies.html', 'Go to cookie settings page');
-ok(!$sel->is_visible('moz-consent-banner'),
+ok(!$sel->click_ok('moz-consent-banner-button-accept')
   'Cookie banner hidden on cookie settings page');
 
 # Accept all cookies for admin user

--- a/qa/t/1_test_cookie_consent.t
+++ b/qa/t/1_test_cookie_consent.t
@@ -23,7 +23,7 @@ set_parameters($sel,
 
 # Verify that the cookie banner is hidden on the cookie settings page
 $sel->open_ok('/page.cgi?id=cookies.html', 'Go to cookie settings page');
-ok(!$sel->click_ok('moz-consent-banner-button-accept')
+ok(!$sel->click_ok('moz-consent-banner-button-accept'),
   'Cookie banner hidden on cookie settings page');
 
 # Accept all cookies for admin user

--- a/qa/t/1_test_cookie_consent.t
+++ b/qa/t/1_test_cookie_consent.t
@@ -23,7 +23,7 @@ set_parameters($sel,
 
 # Verify that the cookie banner is hidden on the cookie settings page
 $sel->open_ok('/page.cgi?id=cookies.html', 'Go to cookie settings page');
-ok(!$sel->is_element_present('moz-consent-banner'),
+ok(!$sel->is_visible('moz-consent-banner'),
   'Cookie banner hidden on cookie settings page');
 
 # Accept all cookies for admin user

--- a/template/en/default/global/footer.html.tmpl
+++ b/template/en/default/global/footer.html.tmpl
@@ -27,7 +27,8 @@
 
 [% USE Bugzilla %]
 [% IF Param("cookie_consent_enabled")
-  && Bugzilla.cgi.cookie_consent_required %]
+  && Bugzilla.cgi.cookie_consent_required
+  && !cookie_consent_hidden %]
 <aside class="moz-consent-banner" id="moz-consent-banner" role="region" aria-label="Cookie Banner" data-nosnippet="true">
   <div class="moz-consent-banner-content">
     <h2  class="moz-consent-banner-heading">Help us improve your [% terms.BugzillaTitle %] experience</h2>
@@ -52,4 +53,3 @@
 [% END %]
 </body>
 </html>
-

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -110,8 +110,8 @@
             config => {
                 basepath => basepath,
                 urlbase => urlbase,
-                cookie_consent_enabled => Param("cookie_consent_enabled"),
-                cookie_consent_required => Bugzilla.cgi.cookie_consent_required,
+                cookie_consent_enabled => Param('cookie_consent_enabled') == '1',
+                cookie_consent_required => Bugzilla.cgi.cookie_consent_required == 1,
                 essential_cookies => constants.ESSENTIAL_COOKIES,
             }
             user => {
@@ -427,7 +427,7 @@
     </strong>
   </div>
   [% END %]
-[% END %] 
+[% END %]
 
 <main id="bugzilla-body" tabindex="-1">
 


### PR DESCRIPTION
[Bug 1976263 - Cookie banner hides cookie page](https://bugzilla.mozilla.org/show_bug.cgi?id=1976263)

- Add a var to hide the banner only on the cookie settings page
- Fix JS-embedded config
  - `Param('cookie_consent_enabled')` is a string, either `'0'` or `'1'`, so cast it to boolean
  - Also cast `Bugzilla.cgi.cookie_consent_required`
