### PR TITLE
Bug 2033409 - Pasting a link from the clipboard after using the Link button inserts additional markdown into the link

### DIFF
--- a/js/text-editor.js
+++ b/js/text-editor.js
@@ -299,7 +299,10 @@ Bugzilla.TextEditor = class TextEditor {
     if (/^https?:\/\/\S+$/.test(data) && URL.canParse(data)) {
       const { start, end, beforeText, selectedText, afterText } = this.getSelection();
 
-      if (selectedText) {
+      // Check if the URL can be inserted as a Markdown link without breaking existing markup; if
+      // the selected text is already part of a Markdown link, the pasted URL will be inserted as
+      // plain text instead to avoid breaking the existing link.
+      if (selectedText && !beforeText.endsWith('](') && !afterText.startsWith(')')) {
         event.preventDefault();
 
         this.updateText(`${beforeText}[${selectedText}](${data})${afterText}`, {


### PR DESCRIPTION
[Bug 2033409 - Pasting a link from the clipboard after using the Link button inserts additional markdown into the link](https://bugzilla.mozilla.org/show_bug.cgi?id=2033409)

Check the current markup before inserting a link.