### PR TITLE
Bug 2035819 - Pasting a link while a link is currently selected adds an extra markdown entry

### DIFF
--- a/js/text-editor.js
+++ b/js/text-editor.js
@@ -305,8 +305,8 @@ Bugzilla.TextEditor = class TextEditor {
       if (
         selectedText &&
         !Bugzilla.String.isURL(selectedText) &&
-        !beforeText.endsWith("](") &&
-        !afterText.startsWith(")")
+        !beforeText.endsWith('](') &&
+        !afterText.startsWith(')')
       ) {
         event.preventDefault();
 

--- a/js/text-editor.js
+++ b/js/text-editor.js
@@ -296,13 +296,18 @@ Bugzilla.TextEditor = class TextEditor {
   textareaOnPaste(event) {
     const data = event.clipboardData?.getData('text');
 
-    if (/^https?:\/\/\S+$/.test(data) && URL.canParse(data)) {
+    if (Bugzilla.String.isURL(data)) {
       const { start, end, beforeText, selectedText, afterText } = this.getSelection();
 
       // Check if the URL can be inserted as a Markdown link without breaking existing markup; if
-      // the selected text is already part of a Markdown link, the pasted URL will be inserted as
-      // plain text instead to avoid breaking the existing link.
-      if (selectedText && !beforeText.endsWith('](') && !afterText.startsWith(')')) {
+      // the selected text is already a valid URL or part of a Markdown link, the pasted URL will be
+      // inserted as plain text instead to avoid breaking the existing link.
+      if (
+        selectedText &&
+        !Bugzilla.String.isURL(selectedText) &&
+        !beforeText.endsWith("](") &&
+        !afterText.startsWith(")")
+      ) {
         event.preventDefault();
 
         this.updateText(`${beforeText}[${selectedText}](${data})${afterText}`, {
@@ -370,7 +375,7 @@ Bugzilla.TextEditor = class TextEditor {
         start: start - 1,
         end: end - 1,
       });
-    } else if (selectedText.match(/^(https?|mailto):/) || !selectedText) {
+    } else if (!selectedText || Bugzilla.String.isURL(selectedText)) {
       // Convert any URL to a markup, and let the user enter the label
       this.updateText(`${beforeText}[](${selectedText ?? 'url'})${afterText}`, {
         start: start + 1,

--- a/js/util.js
+++ b/js/util.js
@@ -963,7 +963,7 @@ Bugzilla.String = class String {
    * @returns {boolean} `true` if the string is a valid URL, `false` otherwise.
    */
   static isURL(string) {
-    return /^(?:https?|mailto):\S+$/.test(string) && URL.canParse(string);
+    return /^(?:https?:\/\/|mailto:)\S+$/.test(string) && URL.canParse(string);
   }
 
   /**

--- a/js/util.js
+++ b/js/util.js
@@ -958,6 +958,15 @@ Bugzilla.Storage = class LocalStorage {
  */
 Bugzilla.String = class String {
   /**
+   * Check if a string is a valid URL.
+   * @param {string} string The string to check.
+   * @returns {boolean} `true` if the string is a valid URL, `false` otherwise.
+   */
+  static isURL(string) {
+    return /^(?:https?|mailto):\/\/\S+$/.test(string) && URL.canParse(string);
+  }
+
+  /**
    * Escape special characters in a string so it can be used for `new RegExp()`.
    * @param {string} string Input string.
    * @returns {string} Escaped string.

--- a/js/util.js
+++ b/js/util.js
@@ -963,7 +963,7 @@ Bugzilla.String = class String {
    * @returns {boolean} `true` if the string is a valid URL, `false` otherwise.
    */
   static isURL(string) {
-    return /^(?:https?|mailto):\/\/\S+$/.test(string) && URL.canParse(string);
+    return /^(?:https?|mailto):\S+$/.test(string) && URL.canParse(string);
   }
 
   /**


### PR DESCRIPTION
[Bug 2035819 - Pasting a link while a link is currently selected adds an extra markdown entry](https://bugzilla.mozilla.org/show_bug.cgi?id=2035819)

Check if the selected text is not a URL to prevent double-pasting, similarly to #2607.