### PR TITLE
Bug 2043429 - Selenium test 1_test_bug_edit.t intermittently fails when attemtping to  click on comment reactions

### DIFF
--- a/Bugzilla/Test/Selenium.pm
+++ b/Bugzilla/Test/Selenium.pm
@@ -66,6 +66,30 @@ sub scroll_to_center {
     'arguments[0].scrollIntoView({block: "center", inline: "nearest"})');
 }
 
+# Use instead of click_ok for elements that don't trigger navigation but are
+# unreliable with WebDriver's native click (e.g. small buttons in containers
+# where ChromeDriver's own scroll-to-click fails with "not interactable").
+sub js_click_ok {
+  my ($self, $locator, $desc) = @_;
+  $desc ||= "Click ok: $locator";
+  TRACE("js_click_ok: $locator, $desc");
+  $locator = $self->_fix_locator($locator);
+  my $element = $self->find_element($locator);
+  if (!$element) {
+    $locator =~ s/\@id/\@name/;
+    TRACE("js_click_ok new locator: $locator");
+    $element = $self->find_element($locator);
+  }
+  if ($element) {
+    $self->scroll_to_center($element);
+    $element->execute_script('arguments[0].click()');
+    ok(1, $desc);
+  }
+  else {
+    ok(0, $desc);
+  }
+}
+
 sub open_ok {
   my ($self, $arg1, $arg2, $name) = @_;
   $arg2 ||= 'undefined';

--- a/qa/t/1_test_bug_edit.t
+++ b/qa/t/1_test_bug_edit.t
@@ -122,7 +122,7 @@ $sel->is_element_present_ok($reactions_picker_path . $reactions_btn1_path
   . '[@aria-pressed="true"]');
 $sel->click_ok($reactions_picker_path . $reactions_btn2_path
   . '[@aria-pressed="false"]');
-$sel->click_ok($reactions_sums_path . $reactions_btn2_path
+$sel->js_click_ok($reactions_sums_path . $reactions_btn2_path
   . '[@data-reaction-count="1"][@aria-pressed="true"]');
 $sel->is_element_present_ok($reactions_sums_path . $reactions_btn2_path
   . '[@data-reaction-count="0"][@aria-pressed="false"]');
@@ -131,7 +131,7 @@ logout($sel);
 # Choose comment reactions by a different user. No privilege required to react
 log_in($sel, $config, 'unprivileged');
 go_to_bug($sel, $bug1_id);
-$sel->click_ok($reactions_sums_path . $reactions_btn1_path
+$sel->js_click_ok($reactions_sums_path . $reactions_btn1_path
   . '[@data-reaction-count="1"][@aria-pressed="false"]');
 $sel->is_element_present_ok($reactions_sums_path . $reactions_btn1_path
   . '[@data-reaction-count="2"][@aria-pressed="true"]');


### PR DESCRIPTION
- Selenium.pm: added js_click_ok — scrolls to center, JS click via arguments[0].click(), no navigation wait (correct since reaction buttons don't navigate)
- 1_test_bug_edit.t: only the two sums button clicks use js_click_ok; all other clicks (anchor, picker, form submits) stay native