### PR TITLE
Bug 1995467 - Show dependency tree on meta bugs by default

### DIFF
--- a/extensions/BMO/Extension.pm
+++ b/extensions/BMO/Extension.pm
@@ -73,6 +73,7 @@ our $VERSION = '0.1';
 BEGIN {
   *Bugzilla::Bug::last_closed_date               = \&_last_closed_date;
   *Bugzilla::Bug::reporters_hw_os                = \&_bug_reporters_hw_os;
+  *Bugzilla::Bug::is_meta                        = \&_bug_is_meta;
   *Bugzilla::Bug::is_unassigned                  = \&_bug_is_unassigned;
   *Bugzilla::Bug::is_untriaged                   = \&_bug_is_untriaged;
   *Bugzilla::Bug::uses_triaged_keyword           = \&_bug_uses_triaged_keyword;
@@ -870,6 +871,11 @@ sub _bug_reporters_hw_os {
     $memcached->set({key => 'bug.ua.' . $self->id, value => $hw_os});
   }
   return $self->{ua_hw_os} = $hw_os;
+}
+
+sub _bug_is_meta {
+  my ($self) = @_;
+  return $self->has_keyword('meta');
 }
 
 sub _bug_is_unassigned {

--- a/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/edit.html.tmpl
@@ -136,6 +136,9 @@
   ELSE;
     firefox_flags_subtitle = "Not tracked";
   END;
+
+  # only show the dependency tree for meta bugs
+  show_dependency_tree = user.id && bug.is_meta
 %]
 
 [% IF user.id %]
@@ -1005,38 +1008,43 @@
 [% WRAPPER bug_modal/module.html.tmpl
   title = "References"
   subtitle = sub
-  collapsed = 1
+  collapsed = !show_dependency_tree
   hide_on_view = !bug.dependson.size && !bug.blocked.size
     && !bug.regresses.size && !bug.regressed_by.size
     && !bug.duplicates.size && !bug.bug_file_loc && !bug.see_also.size;
 %]
-  [% WRAPPER fields_lhs %]
+  [% IF show_dependency_tree %]
+    <div id="dependency-tree-container" class="edit-hide"></div>
+  [% END %]
 
+  [% WRAPPER fields_lhs %]
     [%# dependencies %]
-    [% INCLUDE bug_modal/field.html.tmpl
-        field = bug_fields.dependson
-        field_type = constants.FIELD_TYPE_BUG_LIST
-        values = bug.depends_on_obj
-        hide_on_view = bug.dependson.size == 0
-        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#dependson"
-    %]
-    [% INCLUDE bug_modal/field.html.tmpl
-        field = bug_fields.blocked
-        field_type = constants.FIELD_TYPE_BUG_LIST
-        values = bug.blocks_obj
-        hide_on_view = bug.blocked.size == 0
-        help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#blocks"
-    %]
-    [% IF bug.dependson.size + bug.blocked.size > 0 %]
-      [% WRAPPER bug_modal/field.html.tmpl
-          name = "dependencytree"
-          container = 1
-          label = ""
+    <div id="dependency-list-container" class="edit-show" [%= 'hidden' IF show_dependency_tree %]>
+      [% INCLUDE bug_modal/field.html.tmpl
+          field = bug_fields.dependson
+          field_type = constants.FIELD_TYPE_BUG_LIST
+          values = bug.depends_on_obj
+          hide_on_view = bug.dependson.size == 0
+          help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#dependson"
       %]
-        Dependency <a href="[% basepath FILTER none %]showdependencytree.cgi?id=[% bug.bug_id FILTER none %]&amp;hide_resolved=1">tree</a>
-        / <a href="[% basepath FILTER none %]showdependencygraph.cgi?id=[% bug.bug_id FILTER none %]">graph</a>
+      [% INCLUDE bug_modal/field.html.tmpl
+          field = bug_fields.blocked
+          field_type = constants.FIELD_TYPE_BUG_LIST
+          values = bug.blocks_obj
+          hide_on_view = bug.blocked.size == 0
+          help = "https://wiki.mozilla.org/BMO/UserGuide/BugFields#blocks"
+      %]
+      [% IF bug.dependson.size + bug.blocked.size > 0 %]
+        [% WRAPPER bug_modal/field.html.tmpl
+            name = "dependencytree"
+            container = 1
+            label = ""
+        %]
+          Dependency <a href="[% basepath FILTER none %]showdependencytree.cgi?id=[% bug.bug_id FILTER none %]&amp;hide_resolved=1">tree</a>
+          / <a href="[% basepath FILTER none %]showdependencygraph.cgi?id=[% bug.bug_id FILTER none %]">graph</a>
+        [% END %]
       [% END %]
-    [% END %]
+    </div>
 
     [%# regressions %]
     [% IF Param('use_regression_fields') %]

--- a/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
+++ b/extensions/BugModal/template/en/default/bug_modal/header.html.tmpl
@@ -74,6 +74,11 @@
     "js/jquery/plugins/contextMenu/contextMenu.css"
   );
 
+  IF user.id && bug.is_meta;
+    javascript_urls.push("js/dependency-tree.js");
+    style_urls.push("skins/standard/dependency-tree.css");
+  END;
+
   # use responsive design for the Enter Bug and Show Bug pages
   responsive = 1
 %]

--- a/extensions/BugModal/web/bug_modal.css
+++ b/extensions/BugModal/web/bug_modal.css
@@ -551,6 +551,29 @@ input[type="number"] {
 }
 
 /**
+ * dependency tree
+ */
+
+#dependency-tree-container:not(:empty) {
+  padding: 10px;
+  width: 100%;
+}
+
+#module-references-content:has(.field:not([style="display:none"])) #dependency-tree-container:not(:empty) {
+  margin-bottom: 10px;
+  border-bottom: 1px solid var(--control-border-color);
+}
+
+#dependency-tree-container h3 {
+  color: var(--secondary-label-color);
+  font-size: inherit;
+}
+
+#hide-dependency-tree-btn {
+  margin-left: auto;
+}
+
+/**
  * attachments
  */
 

--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -109,6 +109,48 @@ function initKeywordsAutocomplete(keywords) {
         .addClass('bz_autocomplete');
 };
 
+/**
+ * Initialize the Dependency Tree module if the container element is present on the page.
+ */
+const initDependencyTree = async () => {
+  const $treeContainer = document.querySelector('#dependency-tree-container');
+  const $listContainer = document.querySelector('#dependency-list-container');
+
+  if (!$treeContainer || !$listContainer) {
+    return;
+  }
+
+  const removeTree = () => {
+    $treeContainer.remove();
+    $listContainer.hidden = false;
+  };
+
+  const { config: { basepath }, bug_id: bugId } = BUGZILLA;
+  const url = `${basepath}showdependencytree.cgi?id=${bugId}&hide_resolved=1&embed=1`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    removeTree();
+
+    return;
+  }
+
+  // Safe to inject HTML as is: same-origin fetch, Template Toolkit escapes all user-supplied data
+  $treeContainer.innerHTML = await response.text();
+  new Bugzilla.DependencyTree();
+
+  // Add a button to hide the dependency tree and show the original flat list of dependencies again
+  const $button = Object.assign(document.createElement('button'), {
+    type: 'button',
+    id: 'hide-dependency-tree-btn',
+    className: 'ghost',
+    textContent: 'Hide Dependency Tree',
+  });
+
+  $button.addEventListener('click', (event) => removeTree(), { once: true });
+  $treeContainer.querySelector('[role="toolbar"]')?.insertAdjacentElement('beforeend', $button);
+};
+
 $(function() {
     'use strict';
 
@@ -1619,6 +1661,7 @@ $(function() {
 
     restoreEditMode();
     restoreSavedBugComment();
+    initDependencyTree();
 });
 
 function confirmUnsafeURL(url) {

--- a/js/dependency-tree.js
+++ b/js/dependency-tree.js
@@ -12,33 +12,226 @@
 var Bugzilla = Bugzilla || {}; // eslint-disable-line no-var
 
 /**
- * Activate a Dependency Tree so the user can expand/collapse trees and highlight duplicates.
+ * Implement the Dependency Tree widget, which is used on the dependency tree page and in the modal
+ * bug page.
  */
 Bugzilla.DependencyTree = class DependencyTree {
   /**
-   * Initialize a new DependencyTree instance.
-   * @param {HTMLUListElement} $tree The topmost element of a tree.
+   * Initialize the dependency tree widget by attaching event listeners to the toolbar and tree
+   * items.
    */
-  constructor($tree) {
-    $tree.querySelectorAll('.expander').forEach($button => {
-      $button.addEventListener('click', event => this.toggle_treeitem(event));
+  constructor() {
+    this.$trees = document.querySelector('#dependency-tree');
+
+    if (!this.$trees || this.$trees.dataset.initialized === '1') {
+      return;
+    }
+
+
+    this.data = this.$trees.dataset;
+    this.data.initialized = '1';
+    this.realDepth = Number(this.data.realDepth);
+    this.uriLimit = BUGZILLA.constant.CGI_URI_LIMIT;
+
+    this.$toolbar = this.$trees.querySelector('[role="toolbar"]');
+    this.$container = this.$trees.querySelector('.tree-container');
+
+    this.activateToolbar();
+    this.activateTrees();
+  }
+
+  /**
+   * Attach event listeners to the toolbar buttons and inputs to handle user interactions.
+   */
+  activateToolbar() {
+    this.$toggleBtn = this.$toolbar.querySelector('[data-id="toggle-visibility"]');
+    this.$setLimitBtn = this.$toolbar.querySelector('[data-id="set-limit"]');
+    this.$removeLimitBtn = this.$toolbar.querySelector('[data-id="remove-limit"]');
+    this.$numberInput = this.$toolbar.querySelector('[data-id="custom-limit"]');
+
+    this.$toolbar.addEventListener('click', async ({ target }) => {
+      if (target.matches('button[type="button"]')) {
+        await this.onAction(target.dataset.id);
+      }
     });
 
-    $tree.querySelectorAll('.duplicate-highlighter').forEach($button => {
-      $button.addEventListener('click', event => this.highlight_duplicates(event));
+    this.$numberInput?.addEventListener('change', async () => {
+      await this.onAction('change-limit');
+    });
+  }
+
+  /**
+   * Handle actions triggered by toolbar buttons or inputs.
+   * @param {string} action The action identifier.
+   */
+  async onAction(action) {
+    // Get current values
+    let maxDepth = Number(this.data.maxDepth || this.realDepth);
+    let hideResolved = this.data.hideResolved === '1';
+
+    const removeLimit = () => {
+      maxDepth = 0;
+      this.$numberInput.value = this.realDepth;
+    };
+
+    // Adjust parameters based on which button was clicked
+    switch (action) {
+      case 'toggle-visibility':
+        hideResolved = !hideResolved;
+
+        break;
+      case 'set-limit':
+        maxDepth = 1;
+        this.$numberInput.value = 1;
+
+        break;
+      case 'remove-limit':
+        removeLimit();
+
+        break;
+      case 'change-limit':
+        maxDepth = Number(this.$numberInput?.value || this.realDepth);
+
+        if (maxDepth === this.realDepth) {
+          removeLimit();
+        }
+
+        break;
+    }
+
+    await this.updateTrees({ maxDepth, hideResolved });
+    this.updateControllers({ maxDepth, hideResolved });
+  }
+
+  /**
+   * Fetch and update the dependency tree HTML based on the given parameters, then inject it into
+   * the page.
+   * @param {object} params Parameters.
+   * @param {number} params.maxDepth The maximum depth to show in the tree.
+   * @param {boolean} params.hideResolved Whether to hide resolved bugs in the tree.
+   */
+  async updateTrees({ maxDepth, hideResolved }) {
+    // Build params for fetch
+    const params = new URLSearchParams({
+      id: this.data.bugId,
+      maxdepth: maxDepth,
+      hide_resolved: hideResolved ? '1' : '0',
     });
 
-    $tree.querySelectorAll('.summary.duplicated .bug-link').forEach($link => {
-      $link.addEventListener('mouseenter', event => this.highlight_duplicates(event));
-      $link.addEventListener('mouseleave', event => this.highlight_duplicates(event));
+    const url = `${this.data.action}?${params}`;
+    const response = await fetch(`${url}&embed=1&tree_only=1`);
+    const html = response.ok ? await response.text() : undefined;
+
+    // Safe to inject HTML as is: same-origin fetch, Template Toolkit escapes all user-supplied data
+    this.$container.innerHTML = html ?? '<p class="error">Failed to load the dependency tree.</p>';
+
+    // Update the URL query parameters if we’re on the dependency tree page
+    if (location.pathname === this.data.action) {
+      history.replaceState(null, '', url);
+    }
+  }
+
+  /**
+   * Update the state of the toolbar buttons and inputs based on the current parameters.
+   * @param {object} params Parameters.
+   * @param {number} params.maxDepth The maximum depth to show in the tree.
+   * @param {boolean} params.hideResolved Whether to hide resolved bugs in the tree.
+   */
+  updateControllers({ maxDepth, hideResolved }) {
+    // Update dataset properties used as state
+    this.data.maxDepth = maxDepth;
+    this.data.hideResolved = hideResolved ? '1' : '0';
+
+    // Update button states
+    this.$toggleBtn.textContent = hideResolved ? 'Show Resolved' : 'Hide Resolved';
+    this.$setLimitBtn.disabled = this.realDepth < 2 || maxDepth === 1;
+    this.$removeLimitBtn.disabled = maxDepth === 0 || maxDepth === this.realDepth;
+  }
+
+  /**
+   * Attach event listeners to the tree items to handle expanding/collapsing and highlighting
+   * duplicates. Use event delegation to handle events on dynamically updated tree items.
+   */
+  activateTrees() {
+    this.$trees.addEventListener('click', (event) => this.onClick(event));
+
+    const onHover = (event) => this.onHover(event);
+
+    this.$trees.addEventListener('mouseenter', onHover, { capture: true });
+    this.$trees.addEventListener('mouseleave', onHover, { capture: true });
+  }
+
+  /**
+   * Handle click events on the tree items. This includes expanding/collapsing tree items and
+   * highlighting duplicates.
+   * @param {MouseEvent} event `click` event.
+   */
+  onClick(event) {
+    if (event.target.matches('.view-list-link')) {
+      const { href, target } = event.target;
+
+      // If the URL is too long, submit it via POST to avoid hitting server limits
+      if (href.length > this.uriLimit) {
+        event.preventDefault();
+        this.submitForm({ href, target });
+      }
+    }
+
+    if (event.target.matches('.expander')) {
+      this.toggleTreeItem(event);
+    }
+
+    if (event.target.matches('.duplicate-highlighter')) {
+      this.highlightDuplicates(event);
+    }
+  }
+
+  /**
+   * Highlight or remove highlights on duplicated tree items when the user hovers over the bug link
+   * in the summary.
+   * @param {MouseEvent} event `mouseenter` or `mouseleave` event.
+   */
+  onHover(event) {
+    if (event.target.matches('.summary.duplicated .bug-link')) {
+      this.highlightDuplicates(event);
+    }
+  }
+
+  /**
+   * Create and submit a hidden form with the given parameters to avoid hitting server limits for
+   * long URLs when the user clicks the “View List” link in the tree.
+   * @param {object} params Parameters.
+   * @param {string} params.href The URL to submit the form to.
+   * @param {string} params.target The target attribute for the form submission.
+   */
+  submitForm({ href, target }) {
+    const { origin, pathname, searchParams } = new URL(href);
+
+    const getInput = (name, value) =>
+      Object.assign(document.createElement('input'), { type: 'hidden', name, value });
+
+    const $form = Object.assign(document.createElement('form'), {
+      method: 'POST',
+      action: origin + pathname,
+      target,
     });
+
+    $form.appendChild(getInput('bug_id', searchParams.get('bug_id')));
+
+    if (searchParams.get('tweak') === '1') {
+      $form.appendChild(getInput('tweak', '1'));
+    }
+
+    document.body.appendChild($form);
+    $form.submit();
+    $form.remove();
   }
 
   /**
    * Expand or collapse one or more tree items.
    * @param {MouseEvent} event `click` event.
    */
-  toggle_treeitem(event) {
+  toggleTreeItem(event) {
     const { target, altKey, ctrlKey, metaKey, shiftKey } = event;
     const $item = target.closest('[role="treeitem"]');
     const expanded = $item.matches('[aria-expanded="false"]');
@@ -48,7 +241,7 @@ Bugzilla.DependencyTree = class DependencyTree {
 
     // Do the same for the subtrees if the Ctrl/Command key is pressed
     if (accelKey && !altKey && !shiftKey) {
-      $item.querySelectorAll('[role="treeitem"]').forEach($child => {
+      $item.querySelectorAll('[role="treeitem"]').forEach(($child) => {
         $child.setAttribute('aria-expanded', expanded);
       });
     }
@@ -58,34 +251,31 @@ Bugzilla.DependencyTree = class DependencyTree {
    * Highlight one or more duplicated tree items.
    * @param {MouseEvent} event `click`, `mouseenter` or `mouseleave` event.
    */
-  highlight_duplicates(event) {
+  highlightDuplicates(event) {
     const { target, type } = event;
     const id = Number(target.closest('[role="treeitem"]').dataset.id);
     const pressed = type === 'click' ? target.matches('[aria-pressed="false"]') : undefined;
+    const $tree = target.closest('[role="tree"]');
+    const { highlighted } = $tree.dataset;
 
-    if (type.startsWith('mouse') && this.highlighted) {
+    if (type.startsWith('mouse') && highlighted) {
       return;
     }
 
     if (type === 'click') {
-      if (this.highlighted) {
+      if (highlighted) {
         // Remove existing highlights
-        document.querySelectorAll(`[role="treeitem"][data-id="${this.highlighted}"]`).forEach($item => {
-          const $highlighter = $item.querySelector('.duplicate-highlighter');
-
-          if ($highlighter) {
-            $highlighter.setAttribute('aria-pressed', 'false');
-          }
-
+        $tree.querySelectorAll(`[role="treeitem"][data-id="${highlighted}"]`).forEach(($item) => {
+          $item.querySelector('.duplicate-highlighter')?.setAttribute('aria-pressed', 'false');
           $item.querySelector('.summary').classList.remove('highlight');
         });
       }
 
       target.setAttribute('aria-pressed', pressed);
-      this.highlighted = pressed ? id : undefined;
+      $tree.dataset.highlighted = pressed ? id : '';
     }
 
-    document.querySelectorAll(`[role="treeitem"][data-id="${id}"]`).forEach(($item, index) => {
+    $tree.querySelectorAll(`[role="treeitem"][data-id="${id}"]`).forEach(($item, index) => {
       $item.querySelector('.summary').classList.toggle('highlight', pressed);
 
       if (index === 0 && pressed) {
@@ -95,8 +285,10 @@ Bugzilla.DependencyTree = class DependencyTree {
   }
 };
 
-window.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('[role="tree"]').forEach($tree => {
-    new Bugzilla.DependencyTree($tree);
-  });
-}, { once: true });
+window.addEventListener(
+  'DOMContentLoaded',
+  () => {
+    new Bugzilla.DependencyTree();
+  },
+  { once: true },
+);

--- a/showdependencytree.cgi
+++ b/showdependencytree.cgi
@@ -72,6 +72,10 @@ $vars->{'realdepth'}     = $realdepth;
 $vars->{'maxdepth'}      = $maxdepth;
 $vars->{'hide_resolved'} = $hide_resolved;
 
+# Extra parameters for embedding the tree in the bug page.
+$vars->{'embed'}     = $cgi->param('embed') ? 1 : 0;
+$vars->{'tree_only'} = $cgi->param('tree_only') ? 1 : 0;
+
 print $cgi->header();
 $template->process("bug/dependency-tree.html.tmpl", $vars)
   || ThrowTemplateError($template->error());
@@ -103,13 +107,11 @@ sub GenerateTree {
 sub _generate_bug_ids {
   my ($bug_id, $relationship, $depth, $ids) = @_;
 
-  # Record this depth in the global $realdepth variable if it's farther
-  # than we've gone before.
-  $realdepth = max($realdepth, $depth);
-
   my $dependencies = _get_dependencies($bug_id, $relationship);
   foreach my $dep_id (@$dependencies) {
     if (!$maxdepth || $depth <= $maxdepth) {
+      # Record the depth of this dependency if it's the deepest seen so far.
+      $realdepth = max($realdepth, $depth);
       $ids->{$dep_id} = 1;
       _generate_bug_ids($dep_id, $relationship, $depth + 1, $ids);
     }
@@ -148,4 +150,3 @@ sub _get_dependencies {
     : Bugzilla::Bug::list_relationship('dependencies', 'dependson', 'blocked',
       $bug_id, $hide_resolved);
 }
-

--- a/skins/standard/dependency-tree.css
+++ b/skins/standard/dependency-tree.css
@@ -5,70 +5,102 @@
  * This Source Code Form is "Incompatible With Secondary Licenses", as
  * defined by the Mozilla Public License, v. 2.0. */
 
-[role="button"] {
+#main-inner > #dependency-tree [role="toolbar"] {
+  position: sticky;
+  top: calc(var(--global-header-height) + 16px);
+  z-index: 100;
+  background-color: var(--application-background-color);
+}
+
+#dependency-tree [role="toolbar"] {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+#dependency-tree [role="toolbar"] [role="group"] {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 4px;
+}
+
+#dependency-tree .tree-container > [role="group"] {
+  margin-block: 16px 0;
+}
+
+#dependency-tree .tree-container h3 {
+  margin-block: 0 8px;
+}
+
+#dependency-tree .tree-container p {
+  margin-block: 0;
+}
+
+#dependency-tree [role="tree"] {
+  display: block;
+  margin: 8px 0 0 22px;
+  padding: 0;
+}
+
+#dependency-tree [role="tree"] [role="button"] {
   outline: 0;
   border: 0;
   padding: 0 !important;
+  width: 18px !important;
+  height: 18px !important;
   color: inherit;
   background: none transparent !important;
   box-shadow: none !important;
   font-size: inherit;
   font-weight: normal;
+  vertical-align: top;
   transition: none;
 }
 
-[role="button"] * {
+#dependency-tree [role="tree"] [role="button"] * {
   pointer-events: none;
 }
 
-[role="tree"] {
-  display: block;
-  margin: 16px 0 0 22px;
-  padding: 0;
-}
-
-[role="tree"] ul {
+#dependency-tree [role="tree"] ul {
   display: block;
   margin: 0;
   padding: 0 0 0 44px;
 }
 
-[role="tree"] li {
+#dependency-tree [role="tree"] li {
   display: block;
   margin: 8px 0;
   padding: 0;
   list-style-type: none;
 }
 
-[role="tree"] .icon::before {
+#dependency-tree [role="tree"] .icon::before {
   font-size: var(--icon-size-small);
   font-family: var(--icon-font-family);
   line-height: 100%;
   vertical-align: top;
 }
 
-[role="treeitem"][aria-expanded] {
+#dependency-tree [role="treeitem"][aria-expanded] {
   margin-left: -22px;
 }
 
-[role="treeitem"][aria-expanded="true"] > .expander .icon {
+#dependency-tree [role="treeitem"][aria-expanded="true"] > .expander .icon {
   transform: rotate(90deg);
 }
 
-[role="treeitem"][aria-expanded="false"] > .expander .icon {
+#dependency-tree [role="treeitem"][aria-expanded="false"] > .expander .icon {
   transform: rotate(0);
 }
 
-[role="treeitem"][aria-expanded="false"] [role="group"] {
+#dependency-tree [role="treeitem"][aria-expanded="false"] [role="group"] {
   display: none;
 }
 
-.expander {
-  width: 18px !important;
-  height: 18px;
-}
-
-.expander .icon {
+#dependency-tree .expander .icon {
   display: inline-block;
   width: 18px;
   height: 18px;
@@ -76,28 +108,28 @@
   transition: transform .2s;
 }
 
-.expander .icon::before {
+#dependency-tree .expander .icon::before {
   content: '\E037';
 }
 
-.tree-link .icon::before {
+#dependency-tree .tree-link .icon::before {
   content: '\E0B8';
 }
 
-.duplicate-highlighter[aria-pressed="true"] {
+#dependency-tree .duplicate-highlighter[aria-pressed="true"] {
   color: rgb(var(--accent-color-red-1));
 }
 
-.duplicate-highlighter .icon::before {
+#dependency-tree .duplicate-highlighter .icon::before {
   content: '\E417';
 }
 
-.summary.highlight .bug-link {
+#dependency-tree .summary.highlight .bug-link {
   background-color: var(--selected-control-background-color) !important;
   font-weight: 500 !important;
 }
 
-.summ_info {
+#dependency-tree .summ_info {
   display: none; /* change to inline if you would like to see the full bug details displayed in the list */
   font-size: 75%;
 }

--- a/template/en/default/bug/dependency-tree.html.tmpl
+++ b/template/en/default/bug/dependency-tree.html.tmpl
@@ -184,7 +184,7 @@
 [% BLOCK depth_control_toolbar %]
   <div role="toolbar" aria-label="Dependency tree controls">
     <button type="button" data-id="toggle-visibility" class="secondary"
-        aria-label="Toggle visibility of resolved bugs in the tree">
+        aria-label="Toggle visibility of resolved [% terms.bugs %] in the tree">
       [% IF hide_resolved %]Show[% ELSE %]Hide[% END %] Resolved
     </button>
     <div role="group" aria-label="Max depth control">
@@ -192,7 +192,7 @@
       <input type="number" data-id="custom-limit"
           size="4" maxlength="4" min="1" max="[% realdepth FILTER html %]"
           value="[% maxdepth > 0 && maxdepth <= realdepth ? maxdepth : realdepth %]"
-          aria-label="Set maximum depth of the dependency tree.">
+          aria-label="Set maximum depth of the dependency tree">
       <button type="button" data-id="set-limit" class="secondary"
           [% " disabled" IF realdepth < 2 || maxdepth == 1 %]
           aria-label="Set maximum depth to 1">1</button>

--- a/template/en/default/bug/dependency-tree.html.tmpl
+++ b/template/en/default/bug/dependency-tree.html.tmpl
@@ -24,25 +24,48 @@
 [% PROCESS 'global/field-descs.none.tmpl' %]
 
 [% filtered_desc = blocked_tree.$bugid.short_desc FILTER html %]
-[% PROCESS global/header.html.tmpl
-   title           = "Dependency tree for $terms.Bug $bugid"
-   header          = "Dependency tree for
-                      <a href=\"${basepath}show_bug.cgi?id=$bugid\">$terms.Bug $bugid</a>"
-   javascript_urls = ["js/dependency-tree.js"]
-   style_urls      = ["skins/standard/dependency-tree.css"]
-   subheader      = filtered_desc
-   doc_section = "hintsandtips.html#dependencytree"
-%]
 
-[% PROCESS depthControlToolbar %]
+[% IF !embed %]
+  [% PROCESS global/header.html.tmpl
+    title           = "Dependency tree for $terms.Bug $bugid"
+    header          = "Dependency tree for
+                        <a href=\"${basepath}show_bug.cgi?id=$bugid\">$terms.Bug $bugid</a>"
+    javascript_urls = ["js/dependency-tree.js"]
+    style_urls      = ["skins/standard/dependency-tree.css"]
+    subheader       = filtered_desc
+    doc_section     = "hintsandtips.html#dependencytree"
+  %]
+[% END %]
 
-[% INCLUDE tree_section ids=dependson_ids type=1 %]
+[% IF embed && tree_only %]
+  [% INCLUDE trees %]
+[% ELSE %]
+  <div id="dependency-tree"
+      role="group" aria-label="Dependency tree for [% terms.Bug %] [%= bugid %]"
+      data-action="[% basepath FILTER none %]showdependencytree.cgi"
+      data-bug-id="[% bugid %]"
+      data-max-depth="[% maxdepth %]"
+      data-real-depth="[% realdepth %]"
+      data-hide-resolved="[% hide_resolved %]">
+    [% INCLUDE depth_control_toolbar %]
+    <div class="tree-container">
+      [% INCLUDE trees %]
+    </div>
+  </div>
+[% END %]
 
-[% INCLUDE tree_section ids=blocked_ids type=2 %]
+[% IF !embed %]
+  [% PROCESS global/footer.html.tmpl %]
+[% END %]
 
-[% PROCESS depthControlToolbar %]
+[%###########################################################################%]
+[%# Trees                                                                   #%]
+[%###########################################################################%]
 
-[% PROCESS global/footer.html.tmpl %]
+[% BLOCK trees %]
+  [% INCLUDE tree_section ids=dependson_ids type=1 label="Depends on" %]
+  [% INCLUDE tree_section ids=blocked_ids type=2 label="Blocked by" %]
+[% END %]
 
 [%###########################################################################%]
 [%# Tree-drawing blocks                                                     #%]
@@ -57,55 +80,42 @@
     #%]
   [% global.seen = {} %]
   [%# Display the tree of bugs that this bug depends on. %]
-  <h3>
-    <a href="[% basepath FILTER none %]show_bug.cgi?id=[% bugid %]">[% terms.Bug %] [%+ bugid %]</a>
-    [% IF type == 1 %]
-        [% tree_name = "dependson_tree" %]
-        [% IF ids.size %]
-            depends on
-        [% ELSE %]
-            does not depend on any [% 'open ' IF hide_resolved %][% terms.bugs %].
-        [% END %]
-    [% ELSIF type == 2 %]
-        [% tree_name = "blocked_tree" %]
-        [% IF ids.size %]
-            blocks
-        [% ELSE %]
-            does not block any [% 'open ' IF hide_resolved %][% terms.bugs %].
-        [% END %]
-    [% END %]
+  <div role="group" aria-label="[% label FILTER html %]">
+    <h3>
+      [%- terms.Bug %] [%= bugid -%]
+      [%- IF type == 1 -%]
+        [%- tree_name = "dependson_tree" -%]
+        [%- IF ids.size %] depends on[%- ELSE %] does not depend on any [%= 'open ' IF hide_resolved -%][%- terms.bugs %].[%- END -%]
+      [%- ELSIF type == 2 -%]
+        [%- tree_name = "blocked_tree" -%]
+        [%- IF ids.size %] blocks[%- ELSE %] does not block any [%= 'open ' IF hide_resolved -%][%- terms.bugs %].[%- END -%]
+      [%- END -%]
+      [%- IF ids.size %]
+        [%= (ids.size == 1) ? "one" : ids.size -%]
+        [%- IF hide_resolved %] open[%- END -%]
+        [%- " " _ ((ids.size == 1) ? terms.bug : terms.bugs) %]:
+      [%- END -%]
+    </h3>
     [% IF ids.size %]
-        [%+ (ids.size == 1) ? "one" : ids.size %]
-        [%+ IF hide_resolved %]open[% END %]
-        [%+ (ids.size == 1) ? terms.bug : terms.bugs %]:
+      <p>
+        [% IF maxdepth -%]Up to [% maxdepth %] level[% "s" IF maxdepth > 1 %] deep[% END -%]
+        [% IF maxdepth && ids.size > 1 +%] | [%+ END %]
+        [% href = basepath _ 'buglist.cgi?bug_id=' _ ids.sort().join(",") %]
+        [% IF ids.size > 1 %]
+          <a href="[% href FILTER none %]" class="view-list-link"
+              [% IF embed %]target="_blank"[% END %]>View as [% terms.bug %] list</a>
+          [% IF user.in_group('editbugs') %]
+            |
+            <a href="[% href FILTER none %]&amp;tweak=1" class="view-list-link"
+                [% IF embed %]target="_blank"[% END %]>Change several</a>
+          [% END %]
+        [% END %]
+      </p>
+      <ul role="tree">
+        [% INCLUDE display_tree tree=$tree_name %]
+      </ul>
     [% END %]
-  </h3>
-  [% IF ids.size %]
-    [%# 27 chars is the length of buglist.cgi?tweak=&bug_id=" %]
-    [% use_post = (ids.join(",").length > constants.CGI_URI_LIMIT - 27 ) ? 1 : 0 %]
-    [% IF use_post %]
-      <form action="[% basepath FILTER none %]buglist.cgi" method="post">
-      <input type="hidden" name="bug_id" value="[% ids.join(",") %]">
-    [% END %]
-
-    [% IF maxdepth -%]Up to [% maxdepth %] level[% "s" IF maxdepth > 1 %] deep | [% END -%]
-    [% IF use_post %]
-      <button>view as [% terms.bug %] list</button>
-      [% IF user.in_group('editbugs') && ids.size > 1 %]
-        | <button type="submit" name="tweak" value="1">change several</button>
-      [% END %]
-      </form>
-    [% ELSE %]
-      <a href="[% basepath FILTER none %]buglist.cgi?bug_id=[% ids.join(",") %]">view as [% terms.bug %] list</a>
-      [% IF user.in_group('editbugs') && ids.size > 1 %]
-        | <a href="[% basepath FILTER none %]buglist.cgi?bug_id=[% ids.join(",") %]&amp;tweak=1">change several</a>
-      [% END %]
-    [% END %]
-
-    <ul role="tree">
-      [% INCLUDE display_tree tree=$tree_name %]
-    </ul>
-  [% END %]
+  </div>
 [% END %]
 
 
@@ -148,13 +158,15 @@
 
 [% BLOCK buglink %]
   <a class="bug-link[% ' bz_closed' UNLESS bug.isopened %]"
-     href="[% basepath FILTER none %]show_bug.cgi?id=[% bugid %]" title="[% INCLUDE buginfo bug=bug %]">
+      href="[% basepath FILTER none %]show_bug.cgi?id=[% bugid %]" title="[% INCLUDE buginfo bug=bug %]"
+      [% IF embed %]target="_blank"[% END %]>
     <strong>[%- bugid %]:</strong>
     <span class="summ_text">[%+ bug.short_desc FILTER html %]</span>
     <span class="summ_info">[[% INCLUDE buginfo %]]</span>
   </a>
   <a class="tree-link iconic" href="[% basepath FILTER none %]showdependencytree.cgi?id=[% bugid FILTER uri %]"
-      title="See dependency tree for [% terms.Bug %] [%+ bugid FILTER html %]">
+      title="See dependency tree for [% terms.Bug %] [%+ bugid FILTER html %]"
+      [% IF embed %]target="_blank"[% END %]>
     <span class="icon" aria-hidden="true"></span>
   </a>
 [% END %]
@@ -169,105 +181,24 @@
 [%# Block for depth control toolbar                                         #%]
 [%###########################################################################%]
 
-[% BLOCK depthControlToolbar %]
- <table cellpadding="3" border="0" cellspacing="0">
-   <tr>
-   [%# Hide/show resolved button
-       Swaps text depending on the state of hide_resolved %]
-   <td align="center">
-   <form method="get" action="[% basepath FILTER none %]showdependencytree.cgi"
-           style="display: inline; margin: 0px;">
-     <input name="id" type="hidden" value="[% bugid %]">
-     [% IF maxdepth %]
-       <input name="maxdepth" type="hidden" value="[% maxdepth %]">
-     [% END %]
-     <input type="hidden" name="hide_resolved" value="[% hide_resolved ? 0 : 1 %]">
-     <input type="submit" id="toggle_visibility"
-            value="[% IF hide_resolved %]Show[% ELSE %]Hide[% END %] Resolved">
-   </form>
-   </td>
-
-   <td>
-     Max Depth:
-   </td>
-
-   <td>
-     &nbsp;
-   </td>
-
-   <td>
-   <form method="get" action="[% basepath FILTER none %]showdependencytree.cgi"
-         style="display: inline; margin: 0px;">
-     [%# set to one form %]
-     <input type="submit" id="change_maxdepth"
-       value="&nbsp;1&nbsp;"
-       [% " disabled" IF realdepth < 2 || maxdepth == 1 %]>
-     <input name="id" type="hidden" value="[% bugid %]">
-     <input name="maxdepth" type="hidden" value="1">
-     <input name="hide_resolved" type="hidden" value="[% hide_resolved %]">
-   </form>
-   </td>
-
-   <td>
-   <form method="get" action="[% basepath FILTER none %]showdependencytree.cgi"
-         style="display: inline; margin: 0px;">
-     [%# Minus one form
-         Allow subtracting only when realdepth and maxdepth > 1 %]
-     <input name="id" type="hidden" value="[% bugid %]">
-     <input name="maxdepth" type="hidden" value="[%
-         maxdepth == 1 ? 1
-                       : ( maxdepth ? maxdepth - 1 : realdepth - 1 )
-     %]">
-     <input name="hide_resolved" type="hidden" value="[% hide_resolved %]">
-     <input type="submit" id="decrease_depth" value="&nbsp;&lt;&nbsp;"
-       [% " disabled" IF realdepth < 2 || ( maxdepth && maxdepth < 2 ) %]>
-   </form>
-   </td>
-
-   <td>
-   <form method="get" action="[% basepath FILTER none %]showdependencytree.cgi"
-         style="display: inline; margin: 0px;">
-     [%# Limit entry form: the button can not do anything when total depth
-         is less than two, so disable it %]
-     <input name="maxdepth" size="4" maxlength="4" value="[%
-         maxdepth > 0 && maxdepth <= realdepth ? maxdepth : ""
-     %]">
-     <input name="id" type="hidden" value="[% bugid %]">
-     <input name="hide_resolved" type="hidden" value="[% hide_resolved %]">
-     <noscript>
-       <input type="submit" id="change_depth" value="Change"
-              [% " disabled" IF realdepth < 2 %]>
-     </noscript>
-   </form>
-   </td>
-
-   <td>
-   <form method="get" action="[% basepath FILTER none %]showdependencytree.cgi"
-         style="display: inline; margin: 0px;">
-     [%# plus one form
-         Disable button if total depth < 2, or if depth set to unlimited %]
-     <input name="id" type="hidden" value="[% bugid %]">
-     [% IF maxdepth %]
-       <input name="maxdepth" type="hidden" value="[% maxdepth + 1 %]">
-     [% END %]
-     <input name="hide_resolved" type="hidden" value="[% hide_resolved %]">
-     <input type="submit" id="increase_depth" value="&nbsp;&gt;&nbsp;"
-        [% " disabled" IF realdepth < 2 || !maxdepth || maxdepth >= realdepth %]>
-   </form>
-   </td>
-
-   <td>
-   <form method="get" action="[% basepath FILTER none %]showdependencytree.cgi"
-         style="display: inline; margin: 0px;">
-     [%# Unlimited button %]
-     <input name="id" type="hidden" value="[% bugid %]">
-     <input name="hide_resolved" type="hidden" value="[% hide_resolved %]">
-     <input type="submit" id="remove_limit"
-       value="&nbsp;Unlimited&nbsp;"
-       [% " disabled" IF maxdepth == 0 || maxdepth == realdepth %]>
-   </form>
-   </td>
- </tr>
-</table>
-
+[% BLOCK depth_control_toolbar %]
+  <div role="toolbar" aria-label="Dependency tree controls">
+    <button type="button" data-id="toggle-visibility" class="secondary"
+        aria-label="Toggle visibility of resolved bugs in the tree">
+      [% IF hide_resolved %]Show[% ELSE %]Hide[% END %] Resolved
+    </button>
+    <div role="group" aria-label="Max depth control">
+      <span aria-hidden="true">Max Depth:</span>
+      <input type="number" data-id="custom-limit"
+          size="4" maxlength="4" min="1" max="[% realdepth FILTER html %]"
+          value="[% maxdepth > 0 && maxdepth <= realdepth ? maxdepth : realdepth %]"
+          aria-label="Set maximum depth of the dependency tree.">
+      <button type="button" data-id="set-limit" class="secondary"
+          [% " disabled" IF realdepth < 2 || maxdepth == 1 %]
+          aria-label="Set maximum depth to 1">1</button>
+      <button type="button" data-id="remove-limit" class="secondary"
+          [% " disabled" IF maxdepth == 0 || maxdepth == realdepth %]
+          aria-label="Remove maximum depth limit">Unlimited</button>
+    </div>
+  </div>
 [% END %]

--- a/template/en/default/filterexceptions.pl
+++ b/template/en/default/filterexceptions.pl
@@ -128,9 +128,8 @@
   'bug/dependency-graph.html.tmpl' => [ 'bug_id',],
 
   'bug/dependency-tree.html.tmpl' => [
-    'bugid', 'maxdepth', 'hide_resolved', 'ids.join(",")', 'maxdepth + 1',
-    'maxdepth > 0 && maxdepth <= realdepth ? maxdepth : ""', 'maxdepth == 1 ? 1
-                       : ( maxdepth ? maxdepth - 1 : realdepth - 1 )',
+    'bugid', 'maxdepth', 'hide_resolved', 'realdepth',
+    'maxdepth > 0 && maxdepth <= realdepth ? maxdepth : realdepth',
   ],
 
   'bug/edit.html.tmpl' => [

--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -127,6 +127,7 @@
                 allow_attachment_display => Param('allow_attachment_display') == '1',
             },
             constant => {
+                CGI_URI_LIMIT => constants.CGI_URI_LIMIT,
                 COMMENT_COLS => constants.COMMENT_COLS,
             },
             string => {


### PR DESCRIPTION
[Bug 1995467 - Show dependency tree on meta bugs by default](https://bugzilla.mozilla.org/show_bug.cgi?id=1995467)

Here’s an overdue PR for my assigned task 🙇🏼 

- Add the `is_meta` property to bug objects in the BMO extension as the `meta` keyword convention is BMO-specific.
- Overhaul the legacy Dependency Tree page to support dynamic loading and toggling of the tree view without a full page reload.
- For meta bugs, replace the flat dependency list in the References section with an embedded interactive tree widget loaded via `showdependencytree.cgi?embed=1`. This provides the same experience as the standalone tree page, but without leaving the bug page.
- Add a Hide Dependency Tree button to revert to the flat list; References module starts expanded for meta bugs.
- Fix the off-by-one `$realdepth` bug. It was incremented unconditionally on every recursive call, inflating the value by 1.