### PR TITLE
Bug 1764713 - Easily switch between open/closed/both combined bugs in bug search list

### DIFF
--- a/buglist.cgi
+++ b/buglist.cgi
@@ -29,6 +29,7 @@ use Bugzilla::Status;
 use Bugzilla::Token;
 
 use Date::Parse;
+use List::Util qw(any);
 use List::MoreUtils qw(uniq);
 
 
@@ -890,13 +891,13 @@ $vars->{'closedstates'} = [map { $_->name } closed_bug_statuses()];
 # Determine which status filter tab is active for the toggle UI.
 {
   my @requested = $params->param('bug_status');
-  if (!@requested || grep { $_ eq '__all__' } @requested) {
+  if (!@requested || any { $_ eq '__all__' } @requested) {
     $vars->{'status_filter'} = 'all';
   }
-  elsif (grep { $_ eq '__open__' } @requested) {
+  elsif (any { $_ eq '__open__' } @requested) {
     $vars->{'status_filter'} = 'open';
   }
-  elsif (grep { $_ eq '__closed__' } @requested) {
+  elsif (any { $_ eq '__closed__' } @requested) {
     $vars->{'status_filter'} = 'closed';
   }
   else {

--- a/buglist.cgi
+++ b/buglist.cgi
@@ -889,7 +889,7 @@ $vars->{'closedstates'} = [map { $_->name } closed_bug_statuses()];
 
 # Determine which status filter tab is active for the toggle UI.
 {
-  my @requested = $cgi->param('bug_status');
+  my @requested = $params->param('bug_status');
   if (!@requested || grep { $_ eq '__all__' } @requested) {
     $vars->{'status_filter'} = 'all';
   }

--- a/buglist.cgi
+++ b/buglist.cgi
@@ -887,6 +887,35 @@ $vars->{'displaycolumns'} = \@displaycolumns;
 $vars->{'openstates'} = [BUG_STATE_OPEN];
 $vars->{'closedstates'} = [map { $_->name } closed_bug_statuses()];
 
+# Determine which status filter tab is active for the toggle UI.
+{
+  my @requested = $cgi->param('bug_status');
+  if (!@requested || grep { $_ eq '__all__' } @requested) {
+    $vars->{'status_filter'} = 'all';
+  }
+  elsif (grep { $_ eq '__open__' } @requested) {
+    $vars->{'status_filter'} = 'open';
+  }
+  elsif (grep { $_ eq '__closed__' } @requested) {
+    $vars->{'status_filter'} = 'closed';
+  }
+  else {
+    my %open_set   = map { $_ => 1 } BUG_STATE_OPEN;
+    my %closed_set = map { $_ => 1 } map { $_->name } closed_bug_statuses();
+    my $has_open   = grep { $open_set{$_}   } @requested;
+    my $has_closed = grep { $closed_set{$_} } @requested;
+    if ($has_open && !$has_closed) {
+      $vars->{'status_filter'} = 'open';
+    }
+    elsif ($has_closed && !$has_open) {
+      $vars->{'status_filter'} = 'closed';
+    }
+    else {
+      $vars->{'status_filter'} = 'all';
+    }
+  }
+}
+
 # The iCal file needs priorities ordered from 1 to 9 (highest to lowest)
 # If there are more than 9 values, just make all the lower ones 9
 if ($format->{'extension'} eq 'ics') {
@@ -1057,6 +1086,8 @@ else {
 # Set 'urlquerypart' once the buglist ID is known.
 $vars->{'urlquerypart'}
   = $params->canonicalize_query('order', 'cmdtype', 'query_based_on', 'token');
+$vars->{'urlquerypart_no_status'}
+  = $params->canonicalize_query('order', 'cmdtype', 'query_based_on', 'token', 'bug_status');
 
 if ($format->{'extension'} eq "csv") {
 

--- a/buglist.cgi
+++ b/buglist.cgi
@@ -1087,8 +1087,11 @@ else {
 # Set 'urlquerypart' once the buglist ID is known.
 $vars->{'urlquerypart'}
   = $params->canonicalize_query('order', 'cmdtype', 'query_based_on', 'token');
+# Excludes resolution alongside bug_status from the query used by status toggle buttons.
+# resolution is coupled to bug_status, so both must be dropped together
 $vars->{'urlquerypart_no_status'}
-  = $params->canonicalize_query('order', 'cmdtype', 'query_based_on', 'token', 'bug_status');
+  = $params->canonicalize_query('order', 'cmdtype', 'query_based_on', 'token',
+    'bug_status', 'resolution');
 
 if ($format->{'extension'} eq "csv") {
 

--- a/skins/standard/buglist.css
+++ b/skins/standard/buglist.css
@@ -9,6 +9,43 @@
   text-align: center;
 }
 
+.bz_status_toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin: 8px 0;
+}
+
+.bz_status_toggle_label {
+  color: var(--secondary-label-color);
+  font-size: var(--font-size-small);
+  margin-right: 4px;
+}
+
+.bz_status_toggle_btn {
+  display: inline-block;
+  padding: 3px 12px;
+  border: 1px solid var(--secondary-region-border-color);
+  border-radius: 3px;
+  font-size: var(--font-size-small);
+  text-decoration: none;
+  color: var(--link-color);
+  background: transparent;
+  cursor: pointer;
+}
+
+.bz_status_toggle_btn:hover {
+  background: var(--secondary-region-background-color);
+}
+
+.bz_status_toggle_btn.active {
+  background: var(--link-color, #0060df);
+  color: #fff;
+  border-color: transparent;
+  cursor: default;
+  font-weight: 500;
+}
+
 .bz_query_head h1 {
   font-size: var(--font-size-h2);
 }

--- a/skins/standard/buglist.css
+++ b/skins/standard/buglist.css
@@ -29,7 +29,7 @@
   border-radius: 3px;
   font-size: var(--font-size-small);
   text-decoration: none;
-  color: var(--link-color);
+  color: var(--link-text-color);
   background: transparent;
   cursor: pointer;
 }
@@ -39,7 +39,7 @@
 }
 
 .bz_status_toggle_btn.active {
-  background: var(--link-color, #0060df);
+  background: var(--link-text-color);
   color: #fff;
   border-color: transparent;
   cursor: default;

--- a/template/en/default/list/list.html.tmpl
+++ b/template/en/default/list/list.html.tmpl
@@ -124,6 +124,32 @@
 <hr>
 
 [%############################################################################%]
+[%# Status Filter Toggle                                                     #%]
+[%############################################################################%]
+
+[% IF !dotweak %]
+  [% SET base_status_url = basepath _ "buglist.cgi?" _ urlquerypart_no_status %]
+  <div class="bz_status_toggle">
+    <span class="bz_status_toggle_label">Show:</span>
+    [% IF status_filter == 'open' %]
+      <span class="bz_status_toggle_btn active">Open</span>
+    [% ELSE %]
+      <a class="bz_status_toggle_btn" href="[% base_status_url FILTER html %]&amp;bug_status=__open__">Open</a>
+    [% END %]
+    [% IF status_filter == 'closed' %]
+      <span class="bz_status_toggle_btn active">Closed</span>
+    [% ELSE %]
+      <a class="bz_status_toggle_btn" href="[% base_status_url FILTER html %]&amp;bug_status=__closed__">Closed</a>
+    [% END %]
+    [% IF status_filter == 'all' %]
+      <span class="bz_status_toggle_btn active">All</span>
+    [% ELSE %]
+      <a class="bz_status_toggle_btn" href="[% base_status_url FILTER html %]&amp;bug_status=__all__">All</a>
+    [% END %]
+  </div>
+[% END %]
+
+[%############################################################################%]
 [%# Preceding Status Line                                                    #%]
 [%############################################################################%]
 

--- a/template/en/default/list/list.html.tmpl
+++ b/template/en/default/list/list.html.tmpl
@@ -134,17 +134,17 @@
     [% IF status_filter == 'open' %]
       <span class="bz_status_toggle_btn active">Open</span>
     [% ELSE %]
-      <a class="bz_status_toggle_btn" href="[% base_status_url FILTER html %]&amp;bug_status=__open__">Open</a>
+      <a class="bz_status_toggle_btn" href="[% base_status_url FILTER html %]&amp;bug_status=__open__[%- "&order=$qorder" FILTER html IF order %]">Open</a>
     [% END %]
     [% IF status_filter == 'closed' %]
       <span class="bz_status_toggle_btn active">Closed</span>
     [% ELSE %]
-      <a class="bz_status_toggle_btn" href="[% base_status_url FILTER html %]&amp;bug_status=__closed__">Closed</a>
+      <a class="bz_status_toggle_btn" href="[% base_status_url FILTER html %]&amp;bug_status=__closed__[%- "&order=$qorder" FILTER html IF order %]">Closed</a>
     [% END %]
     [% IF status_filter == 'all' %]
       <span class="bz_status_toggle_btn active">All</span>
     [% ELSE %]
-      <a class="bz_status_toggle_btn" href="[% base_status_url FILTER html %]&amp;bug_status=__all__">All</a>
+      <a class="bz_status_toggle_btn" href="[% base_status_url FILTER html %]&amp;bug_status=__all__[%- "&order=$qorder" FILTER html IF order %]">All</a>
     [% END %]
   </div>
 [% END %]


### PR DESCRIPTION
#### Summary

This PR adds a quick-toggle widget at the top of the bug list results page (buglist.cgi), allowing users to switch between open, closed or all bugs without returning to the search form.

#### Details

- buglist.cgi

  - Computes a new template variable status_filter ('open', 'closed', or 'all') by inspecting the bug_status CGI parameters of the current search. Handles both the special aliases (__open__, __closed__, __all__) and explicit lists of individual status names (NEW, ASSIGNED, RESOLVED, etc.)
  - Computes a new template variable urlquerypart_no_status: the current search query string with all bug_status parameters stripped out, used to build toggle links that preserve every other search criterion

- template/en/default/list/list.html.tmpl

  - Adds a `<div class="bz_status_toggle">` immediately after the `<hr>` separator, containing three controls: Open, Closed, All
  - The active state is rendered as a non-clickable `<span>`; the other two are `<a>` links pointing to the current search with bug_status=__open__, bug_status=__closed__, or bug_status=__all__ appended
  - The toggle is hidden in the Change Several Bugs at Once (dotweak) mode

- skins/standard/buglist.css

  Adds styles for the toggle widget following the existing bz_ naming convention:
  
  - `.bz_status_toggle`: Flex container for the widget
  - `.bz_status_toggle_label`: "Show:" label
  - `.bz_status_toggle_btn`: Individual button (link or span)
  - `.bz_status_toggle_btn:hover`: Hover state for inactive buttons
  - `.bz_status_toggle_btn.active`: Active/selected button (filled with --link-color)

#### How it works

The search engine already understands bug_status=__open__, bug_status=__closed__, and bug_status=__all__ as special aliases that expand to the appropriate status sets at query time, so the toggle links are simple and require no server-side changes to the search logic.

#### Additional info

* [bug#1764713](https://bugzilla.mozilla.org/show_bug.cgi?id=1764713)

#### Test plan

1. Run a search returning open bugs (bug_status=__open__) -- Open button is highlighted
2. Click Closed -- redirects to the same search with bug_status=__closed__
3. Click All -- redirects with bug_status=__all__
4. Verify that other search parameters (product, assignee…) are preserved in the redirect
5. Verify display on a search with multiple bug_status values (no button highlighted)