### PR TITLE
Bug 2046200 - Open dependency tree links without resolved bugs by default

### DIFF
--- a/template/en/default/bug/dependency-tree.html.tmpl
+++ b/template/en/default/bug/dependency-tree.html.tmpl
@@ -164,7 +164,8 @@
     <span class="summ_text">[%+ bug.short_desc FILTER html %]</span>
     <span class="summ_info">[[% INCLUDE buginfo %]]</span>
   </a>
-  <a class="tree-link iconic" href="[% basepath FILTER none %]showdependencytree.cgi?id=[% bugid FILTER uri %]&amp;hide_resolved=1"
+  <a class="tree-link iconic"
+      href="[% basepath FILTER none %]showdependencytree.cgi?id=[% bugid FILTER uri %]&amp;hide_resolved=1"
       title="See dependency tree for [% terms.Bug %] [%+ bugid FILTER html %]"
       [% IF embed %]target="_blank"[% END %]>
     <span class="icon" aria-hidden="true"></span>

--- a/template/en/default/bug/dependency-tree.html.tmpl
+++ b/template/en/default/bug/dependency-tree.html.tmpl
@@ -164,7 +164,7 @@
     <span class="summ_text">[%+ bug.short_desc FILTER html %]</span>
     <span class="summ_info">[[% INCLUDE buginfo %]]</span>
   </a>
-  <a class="tree-link iconic" href="[% basepath FILTER none %]showdependencytree.cgi?id=[% bugid FILTER uri %]"
+  <a class="tree-link iconic" href="[% basepath FILTER none %]showdependencytree.cgi?id=[% bugid FILTER uri %]&amp;hide_resolved=1"
       title="See dependency tree for [% terms.Bug %] [%+ bugid FILTER html %]"
       [% IF embed %]target="_blank"[% END %]>
     <span class="icon" aria-hidden="true"></span>


### PR DESCRIPTION
[Bug 2046200 - Open dependency tree links without resolved bugs by default](https://bugzilla.mozilla.org/show_bug.cgi?id=2046200)

Just add the `hide_resolved=1` param to in-tree dependency tree links to hide resolved bugs in the linked pages.