### PR TITLE
Bug 2046794 - Bugs cannot be updated if they contain a meta keyword after recent changes to show dependency tree inline

### DIFF
--- a/template/en/default/bug/dependency-tree.html.tmpl
+++ b/template/en/default/bug/dependency-tree.html.tmpl
@@ -193,9 +193,10 @@
         # input always satisfies its own min/max constraints; otherwise an invalid
         # control here would silently fail the embedding bug change form's checkValidity(). %]
       [% input_max = realdepth > 0 ? realdepth : 1 %]
+      [% depth_value = maxdepth > 0 && maxdepth <= realdepth ? maxdepth : input_max %]
       <input type="number" data-id="custom-limit"
           size="4" maxlength="4" min="1" max="[% input_max FILTER html %]"
-          value="[% maxdepth > 0 && maxdepth <= realdepth ? maxdepth : input_max %]"
+          value="[% depth_value FILTER html %]"
           aria-label="Set maximum depth of the dependency tree">
       <button type="button" data-id="set-limit" class="secondary"
           [% " disabled" IF realdepth < 2 || maxdepth == 1 %]

--- a/template/en/default/bug/dependency-tree.html.tmpl
+++ b/template/en/default/bug/dependency-tree.html.tmpl
@@ -189,9 +189,13 @@
     </button>
     <div role="group" aria-label="Max depth control">
       <span aria-hidden="true">Max Depth:</span>
+      [%# When the tree has no open bugs, realdepth is 0. Floor max/value at 1 so the
+        # input always satisfies its own min/max constraints; otherwise an invalid
+        # control here would silently fail the embedding bug change form's checkValidity(). %]
+      [% input_max = realdepth > 0 ? realdepth : 1 %]
       <input type="number" data-id="custom-limit"
-          size="4" maxlength="4" min="1" max="[% realdepth FILTER html %]"
-          value="[% maxdepth > 0 && maxdepth <= realdepth ? maxdepth : realdepth %]"
+          size="4" maxlength="4" min="1" max="[% input_max FILTER html %]"
+          value="[% maxdepth > 0 && maxdepth <= realdepth ? maxdepth : input_max %]"
           aria-label="Set maximum depth of the dependency tree">
       <button type="button" data-id="set-limit" class="secondary"
           [% " disabled" IF realdepth < 2 || maxdepth == 1 %]


### PR DESCRIPTION
Summary

Root cause: PR #2636/#2637 embed the dependency tree directly into the bug page for meta bugs. The tree HTML is injected (extensions/BugModal/web/bug_modal.js → initDependencyTree) into #dependency-tree-container, which lives inside <form id="changeform"> (edit.html.tmpl lines 145–1463). That injected HTML includes a depth-control <input type="number" min="1" max="[realdepth]">.

The save handler in bug_modal.js:813 does:
if (hasInvalidField || !$form.checkValidity()) return;
checkValidity() validates every control in the form, including the injected number input. When a meta bug's tree has realdepth=0 — no open dependencies, which is now common because [Bug 2046200](https://bugzilla.mozilla.org/show_bug.cgi?id=2046200) (commit fbaac119c) made hide_resolved=1 the default for the embedded fetch — the input renders as min="1" max="0" value="0", which is invalid. So checkValidity() returns false and submit silently returns: no error, no network request. Exactly the reported symptom. Meta bugs that still have open dependencies (realdepth ≥ 1) submit fine, which is why it looked intermittent/meta-specific.

Fix: In template/en/default/bug/dependency-tree.html.tmpl, floor the input's max and value at 1 so the control always satisfies its own constraints, even when realdepth=0. No JS changes needed — the input element stays present (so disableControllers/updateControllers don't hit a null), and the depth toolbar is harmless/disabled on an empty tree anyway. The standalone tree page is unaffected (it has no surrounding validated form, and max=1 value=1 is more correct than the previous 0).

This is a one-template quick fix rather than a back-out, so the embedded dependency tree feature stays in place.