### PR TITLE
Bug 1834454 part 2 - Webhooks - look at payload not bug_data

### DIFF
--- a/extensions/Push/lib/Connector/Webhook.pm
+++ b/extensions/Push/lib/Connector/Webhook.pm
@@ -90,8 +90,8 @@ sub should_send {
   if ($event =~ /change/ && $message->routing_key =~ /\Qbug.modify\E/) {
     my $removed_product = "";
     my $removed_component = "";
-    if (exists $bug_data->{'changes'}) {
-      foreach my $change ($bug_data->{'changes'}) {
+    if (exists $payload->{event}->{changes}) {
+      foreach my $change (@{$payload->{event}->{changes}}) {
         if ($change->{'field'} eq 'product') {
           $removed_product = $change->{'removed'};
         }
@@ -105,7 +105,7 @@ sub should_send {
         $removed_product = $bug_data->{'product'};
       }
       if ($product eq $removed_product
-          && ($component eq $removed_component || $component eq 'any'))
+          && ($component eq $removed_component || $component eq 'Any'))
       {
         return 1;
       }


### PR DESCRIPTION
Over in #2204 we attempted to get webhooks to fire for the matching product if a bug was moving OUT of that product. That patch failed. I finally got some time to try to debug this, and figured out that it was trying to pull the change data out of the wrong object.  Oops. We also had a case mismatch on a case-sensitive compare to test for Any as a component name.

This PR fixes those issues, and hopefully this works now.