### PR TITLE
Bug 1684509 - Add "Close as Invalid" button to close spam/test bugs in one action

### DIFF
--- a/extensions/InvalidBugHelper/Config.pm
+++ b/extensions/InvalidBugHelper/Config.pm
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::InvalidBugHelper;
+
+use 5.10.1;
+use strict;
+use warnings;
+
+use constant NAME => 'InvalidBugHelper';
+use constant REQUIRED_MODULES => [];
+use constant OPTIONAL_MODULES => [];
+
+__PACKAGE__->NAME;

--- a/extensions/InvalidBugHelper/Extension.pm
+++ b/extensions/InvalidBugHelper/Extension.pm
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::InvalidBugHelper;
+
+use 5.10.1;
+use strict;
+use warnings;
+
+use base qw(Bugzilla::Extension);
+
+our $VERSION = '1';
+
+sub config_add_panels {
+  my ($self, $args) = @_;
+  $args->{panel_modules}->{InvalidBugHelper}
+    = 'Bugzilla::Extension::InvalidBugHelper::Config';
+}
+
+sub webservice {
+  my ($self, $args) = @_;
+  $args->{dispatch}->{InvalidBugHelper}
+    = 'Bugzilla::Extension::InvalidBugHelper::WebService';
+}
+
+__PACKAGE__->NAME;

--- a/extensions/InvalidBugHelper/lib/Config.pm
+++ b/extensions/InvalidBugHelper/lib/Config.pm
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::InvalidBugHelper::Config;
+
+use 5.10.1;
+use strict;
+use warnings;
+
+use Bugzilla::Config::Common;
+
+our $sortkey = 512;
+
+sub get_param_list {
+  return (
+    {
+      name    => 'invalidbughelper_warning_text',
+      type    => 'l',
+      default =>
+        "This bug has been filed incorrectly as a test or spam submission and has "
+        . "been moved to the Invalid Bugs product.\n\n"
+        . "If you believe this was done in error, please contact "
+        . "bugzilla-admin\@mozilla.org.",
+    },
+  );
+}
+
+1;

--- a/extensions/InvalidBugHelper/lib/WebService.pm
+++ b/extensions/InvalidBugHelper/lib/WebService.pm
@@ -79,15 +79,7 @@ sub close_as_invalid {
     comment           => {body => $warning_text},
   });
 
-  # Strip non-mandatory security groups so the bug becomes public.
-  foreach my $group (@groups) {
-    next if $bug->product_obj->group_is_valid($group)
-      && $bug->product_obj->group_controls->{$group->id}->{membercontrol}
-         == CONTROLMAPMANDATORY
-      && $group->is_active;
-    $bug->remove_group($group);
-  }
-
+  # Non-mandatory security group stripping is handled by _set_product (called via set_all above)
   $bug->update();
 
   # Only tag reporter comments as spam when explicitly requested.

--- a/extensions/InvalidBugHelper/lib/WebService.pm
+++ b/extensions/InvalidBugHelper/lib/WebService.pm
@@ -53,11 +53,12 @@ sub close_as_invalid {
     ThrowUserError('bug_status_unresolvable', {bug => $bug});
   }
 
-  # Snapshot reporter comments and flags before any mutations.
+  # Snapshot reporter comments, flags, and groups before any mutations.
   my @reporter_comments
     = grep { $_->author->id == $bug->reporter->id } @{$bug->comments};
   my @clear_flags = map { {id => $_->id, status => 'X'} }
     grep { $_->type->name eq 'needinfo' } @{$bug->flags};
+  my @groups = @{$bug->groups_in};
 
   my $warning_text = Bugzilla->params->{invalidbughelper_warning_text}
     || 'This bug has been marked as invalid.';
@@ -78,9 +79,7 @@ sub close_as_invalid {
     comment           => {body => $warning_text},
   });
 
-  # Strip security groups so the bug becomes public after the product move.
-  # Copy the array — remove_group mutates groups_in in-place (see Bug.pm:3050).
-  my @groups = @{$bug->groups_in};
+  # Strip non-mandatory security groups so the bug becomes public.
   foreach my $group (@groups) {
     next if $bug->product_obj->group_is_valid($group)
       && $bug->product_obj->group_controls->{$group->id}->{membercontrol}

--- a/extensions/InvalidBugHelper/lib/WebService.pm
+++ b/extensions/InvalidBugHelper/lib/WebService.pm
@@ -90,10 +90,12 @@ sub close_as_invalid {
 
   $bug->update();
 
-  # Tag every reporter comment as spam (triggers AntiSpam user-disable logic).
-  foreach my $comment (@reporter_comments) {
-    $comment->add_tag('spam');
-    $comment->update();
+  # Only tag reporter comments as spam when explicitly requested.
+  if ($params->{mark_as_spam} && $user->can_tag_comments) {
+    foreach my $comment (@reporter_comments) {
+      $comment->add_tag('spam');
+      $comment->update();
+    }
   }
 
   $dbh->bz_commit_transaction();

--- a/extensions/InvalidBugHelper/lib/WebService.pm
+++ b/extensions/InvalidBugHelper/lib/WebService.pm
@@ -35,9 +35,17 @@ sub close_as_invalid {
 
   my $bug = Bugzilla::Bug->check({id => $bug_id});
 
-  ThrowUserError('auth_failure',
-    {action => 'modify', object => 'bug'})
-    unless $user->can_tag_comments;
+  # Block non-members from closing bugs with mandatory security groups.
+  foreach my $group (@{$bug->groups_in}) {
+    my $gc = $bug->product_obj->group_controls->{$group->id};
+    if ($gc
+      && $gc->{membercontrol} == CONTROLMAPMANDATORY
+      && !$user->in_group($group->name))
+    {
+      ThrowUserError('auth_failure',
+        {group => $group->name, action => 'modify', object => 'bug'});
+    }
+  }
 
   if ($bug->bug_status eq 'RESOLVED' || $bug->bug_status eq 'VERIFIED'
       || $bug->product eq 'Invalid Bugs')

--- a/extensions/InvalidBugHelper/lib/WebService.pm
+++ b/extensions/InvalidBugHelper/lib/WebService.pm
@@ -1,0 +1,94 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::InvalidBugHelper::WebService;
+
+use 5.10.1;
+use strict;
+use warnings;
+
+use base qw(Bugzilla::WebService);
+
+use Bugzilla;
+use Bugzilla::Bug;
+use Bugzilla::Comment;
+use Bugzilla::Constants;
+use Bugzilla::Error;
+use constant PUBLIC_METHODS => qw(close_as_invalid);
+
+sub close_as_invalid {
+  my ($self, $params) = @_;
+  my $user = Bugzilla->login(LOGIN_REQUIRED);
+  my $dbh  = Bugzilla->dbh;
+
+  $user->in_group('editbugs')
+    || ThrowUserError('auth_failure',
+    {group => 'editbugs', action => 'update', object => 'bug'});
+
+  my $bug_id = $params->{bug_id}
+    || ThrowCodeError('param_required',
+    {function => 'InvalidBugHelper.close_as_invalid', param => 'bug_id'});
+
+  my $bug = Bugzilla::Bug->check({id => $bug_id});
+
+  # Snapshot reporter comments and flags before any mutations.
+  my @reporter_comments
+    = grep { $_->author->id == $bug->reporter->id } @{$bug->comments};
+  my @clear_flags = map { {id => $_->id, status => 'X'} }
+    grep { $_->type->name eq 'needinfo' } @{$bug->flags};
+
+  my $warning_text = Bugzilla->params->{invalidbughelper_warning_text}
+    || 'This bug has been marked as invalid.';
+
+  $dbh->bz_start_transaction();
+
+  # Clear all needinfo flags.
+  $bug->set_flags(\@clear_flags, []) if @clear_flags;
+
+  # Relocate the bug, resolve it, reset ownership, and post the warning comment.
+  $bug->set_all({
+    product           => 'Invalid Bugs',
+    component         => 'General',
+    bug_status        => 'RESOLVED',
+    resolution        => 'INVALID',
+    reset_assigned_to => 1,
+    reset_qa_contact  => 1,
+    comment           => {body => $warning_text},
+  });
+
+  $bug->update();
+
+  # Tag every reporter comment as spam (triggers AntiSpam user-disable logic).
+  if (Bugzilla->params->{comment_taggers_group} && $user->can_tag_comments()) {
+    foreach my $comment (@reporter_comments) {
+      $comment->add_tag('spam');
+      $comment->update();
+    }
+  }
+
+  $dbh->bz_commit_transaction();
+
+  return {
+    id      => $self->type('int',    $bug->id),
+    product => $self->type('string', $bug->product),
+    status  => $self->type('string', $bug->bug_status),
+  };
+}
+
+sub rest_resources {
+  return [
+    qr{^/invalid_bug_helper/close/(\d+)$},
+    {
+      POST => {
+        method => 'close_as_invalid',
+        params => sub { {bug_id => $_[0]} },
+      },
+    },
+  ];
+}
+
+1;

--- a/extensions/InvalidBugHelper/lib/WebService.pm
+++ b/extensions/InvalidBugHelper/lib/WebService.pm
@@ -30,10 +30,20 @@ sub close_as_invalid {
     {group => 'editbugs', action => 'update', object => 'bug'});
 
   my $bug_id = $params->{bug_id}
-    || ThrowCodeError('param_required',
+    // ThrowCodeError('param_required',
     {function => 'InvalidBugHelper.close_as_invalid', param => 'bug_id'});
 
   my $bug = Bugzilla::Bug->check({id => $bug_id});
+
+  ThrowUserError('auth_failure',
+    {action => 'modify', object => 'bug'})
+    unless $user->can_tag_comments;
+
+  if ($bug->bug_status eq 'RESOLVED' || $bug->bug_status eq 'VERIFIED'
+      || $bug->product eq 'Invalid Bugs')
+  {
+    ThrowUserError('bug_status_unresolvable', {bug => $bug});
+  }
 
   # Snapshot reporter comments and flags before any mutations.
   my @reporter_comments
@@ -61,18 +71,22 @@ sub close_as_invalid {
   });
 
   # Strip security groups so the bug becomes public after the product move.
-  foreach my $group (@{$bug->groups_in}) {
+  # Copy the array — remove_group mutates groups_in in-place (see Bug.pm:3050).
+  my @groups = @{$bug->groups_in};
+  foreach my $group (@groups) {
+    next if $bug->product_obj->group_is_valid($group)
+      && $bug->product_obj->group_controls->{$group->id}->{membercontrol}
+         == CONTROLMAPMANDATORY
+      && $group->is_active;
     $bug->remove_group($group);
   }
 
   $bug->update();
 
   # Tag every reporter comment as spam (triggers AntiSpam user-disable logic).
-  if (Bugzilla->params->{comment_taggers_group} && $user->can_tag_comments()) {
-    foreach my $comment (@reporter_comments) {
-      $comment->add_tag('spam');
-      $comment->update();
-    }
+  foreach my $comment (@reporter_comments) {
+    $comment->add_tag('spam');
+    $comment->update();
   }
 
   $dbh->bz_commit_transaction();

--- a/extensions/InvalidBugHelper/lib/WebService.pm
+++ b/extensions/InvalidBugHelper/lib/WebService.pm
@@ -60,6 +60,11 @@ sub close_as_invalid {
     comment           => {body => $warning_text},
   });
 
+  # Strip security groups so the bug becomes public after the product move.
+  foreach my $group (@{$bug->groups_in}) {
+    $bug->remove_group($group);
+  }
+
   $bug->update();
 
   # Tag every reporter comment as spam (triggers AntiSpam user-disable logic).

--- a/extensions/InvalidBugHelper/template/en/default/admin/params/invalidbughelper.html.tmpl
+++ b/extensions/InvalidBugHelper/template/en/default/admin/params/invalidbughelper.html.tmpl
@@ -14,6 +14,6 @@
 [% param_descs =
 {
   invalidbughelper_warning_text =>
-    "The comment posted on [% terms.bugs %] when they are closed as invalid."
+    "The comment posted on $terms.bugs when they are closed as invalid."
 }
 %]

--- a/extensions/InvalidBugHelper/template/en/default/admin/params/invalidbughelper.html.tmpl
+++ b/extensions/InvalidBugHelper/template/en/default/admin/params/invalidbughelper.html.tmpl
@@ -1,0 +1,19 @@
+[%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  #
+  # This Source Code Form is "Incompatible With Secondary Licenses", as
+  # defined by the Mozilla Public License, v. 2.0.
+  #%]
+
+[%
+  title = "Invalid Bug Helper"
+  desc = "Configure the Close as Invalid feature"
+%]
+
+[% param_descs =
+{
+  invalidbughelper_warning_text =>
+    "The comment posted on [% terms.bugs %] when they are closed as invalid."
+}
+%]

--- a/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/edit-top_actions.html.tmpl
+++ b/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/edit-top_actions.html.tmpl
@@ -1,0 +1,16 @@
+[%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  #
+  # This Source Code Form is "Incompatible With Secondary Licenses", as
+  # defined by the Mozilla Public License, v. 2.0.
+  #%]
+
+[%# Only show for editbugs users on open bugs that are not already in Invalid Bugs %]
+[% IF user.in_group("editbugs")
+     AND bug.bug_status != "RESOLVED"
+     AND bug.bug_status != "VERIFIED"
+     AND bug.product != "Invalid Bugs"
+%]
+| <button type="button" id="close-as-invalid-btn" class="minor">Close as Invalid</button>
+[% END %]

--- a/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/edit-top_actions.html.tmpl
+++ b/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/edit-top_actions.html.tmpl
@@ -24,5 +24,5 @@
    END;
 %]
 [% IF can_close_invalid %]
-| <button type="button" id="close-as-invalid-btn" class="minor">Close as Invalid</button>
+<button type="button" id="close-as-invalid-btn" class="minor">Close as Invalid</button>
 [% END %]

--- a/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/edit-top_actions.html.tmpl
+++ b/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/edit-top_actions.html.tmpl
@@ -6,11 +6,23 @@
   # defined by the Mozilla Public License, v. 2.0.
   #%]
 
-[%# Only show for editbugs users on open bugs that are not already in Invalid Bugs %]
-[% IF user.in_group("editbugs")
+[%# Only show for users who can perform the full close-as-invalid operation %]
+[% can_close_invalid = user.in_group("editbugs")
+     AND user.can_tag_comments
      AND bug.bug_status != "RESOLVED"
      AND bug.bug_status != "VERIFIED"
-     AND bug.product != "Invalid Bugs"
+     AND bug.product != "Invalid Bugs";
+   IF can_close_invalid;
+     FOREACH group IN bug.groups_in;
+       gc = bug.product_obj.group_controls.${group.id};
+       IF gc AND gc.membercontrol == constants.CONTROLMAPMANDATORY
+          AND NOT user.in_group(group.name);
+         can_close_invalid = 0;
+         LAST;
+       END;
+     END;
+   END;
 %]
+[% IF can_close_invalid %]
 | <button type="button" id="close-as-invalid-btn" class="minor">Close as Invalid</button>
 [% END %]

--- a/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/edit-top_actions.html.tmpl
+++ b/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/edit-top_actions.html.tmpl
@@ -8,7 +8,6 @@
 
 [%# Only show for users who can perform the full close-as-invalid operation %]
 [% can_close_invalid = user.in_group("editbugs")
-     AND user.can_tag_comments
      AND user.can_enter_product("Invalid Bugs")
      AND bug.bug_status != "RESOLVED"
      AND bug.bug_status != "VERIFIED"

--- a/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/edit-top_actions.html.tmpl
+++ b/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/edit-top_actions.html.tmpl
@@ -9,6 +9,7 @@
 [%# Only show for users who can perform the full close-as-invalid operation %]
 [% can_close_invalid = user.in_group("editbugs")
      AND user.can_tag_comments
+     AND user.can_enter_product("Invalid Bugs")
      AND bug.bug_status != "RESOLVED"
      AND bug.bug_status != "VERIFIED"
      AND bug.product != "Invalid Bugs";

--- a/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/header-end.html.tmpl
+++ b/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/header-end.html.tmpl
@@ -7,5 +7,6 @@
   #%]
 
 [% IF user.in_group("editbugs") %]
+  [% style_urls.push("extensions/InvalidBugHelper/web/styles/invalid_bug_helper.css") %]
   [% javascript_urls.push("extensions/InvalidBugHelper/web/js/invalid_bug_helper.js") %]
 [% END %]

--- a/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/header-end.html.tmpl
+++ b/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/header-end.html.tmpl
@@ -1,0 +1,11 @@
+[%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  #
+  # This Source Code Form is "Incompatible With Secondary Licenses", as
+  # defined by the Mozilla Public License, v. 2.0.
+  #%]
+
+[% IF user.in_group("editbugs") %]
+  [% javascript_urls.push("extensions/InvalidBugHelper/web/js/invalid_bug_helper.js") %]
+[% END %]

--- a/extensions/InvalidBugHelper/template/en/default/hook/global/user-error-errors.html.tmpl
+++ b/extensions/InvalidBugHelper/template/en/default/hook/global/user-error-errors.html.tmpl
@@ -1,0 +1,12 @@
+[%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  #
+  # This Source Code Form is "Incompatible With Secondary Licenses", as
+  # defined by the Mozilla Public License, v. 2.0.
+  #%]
+
+[% IF error == "bug_status_unresolvable" %]
+  [% title = BLOCK %][% terms.Bug %] Cannot Be Closed as Invalid[% END %]
+  This [% terms.bug %] is already resolved or is in the Invalid [% terms.Bugs %] product.
+[% END %]

--- a/extensions/InvalidBugHelper/web/js/invalid_bug_helper.js
+++ b/extensions/InvalidBugHelper/web/js/invalid_bug_helper.js
@@ -7,22 +7,52 @@
 
 'use strict';
 
+function showCloseDialog(bugId) {
+  return new Promise((resolve) => {
+    const dialog = document.createElement('dialog');
+    dialog.id = 'close-invalid-dialog';
+    dialog.innerHTML = `
+      <form method="dialog">
+        <h3>Close Bug ${bugId} as Invalid</h3>
+        <p>This will:</p>
+        <ul>
+          <li>Move the bug to Invalid Bugs :: General</li>
+          <li>Resolve it as INVALID</li>
+          <li>Clear needinfo flags</li>
+          <li>Post a warning comment</li>
+        </ul>
+        <p><strong>This cannot be undone easily.</strong></p>
+        <hr>
+        <label>
+          <input type="checkbox" id="close-invalid-mark-spam">
+          Also mark the reporter's comments as spam
+        </label>
+        <p class="warning">
+          <span class="warning-icon">&#x26A0;&#xFE0F;</span> May trigger automatic account disabling via AntiSpam.
+          Only check if the reporter is actually a spammer.
+        </p>
+        <div class="actions">
+          <button type="submit" value="cancel">Cancel</button>
+          <button type="submit" value="confirm">Close as Invalid</button>
+        </div>
+      </form>`;
+    dialog.addEventListener('close', () => {
+      const spam = dialog.querySelector('#close-invalid-mark-spam').checked;
+      dialog.remove();
+      resolve(dialog.returnValue === 'confirm' ? { confirmed: true, markAsSpam: spam } : { confirmed: false });
+    });
+    document.body.appendChild(dialog);
+    dialog.showModal();
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('close-as-invalid-btn');
   if (!btn) return;
 
   btn.addEventListener('click', async () => {
     const bugId = BUGZILLA.bug_id;
-    const confirmed = window.confirm(
-      `Close Bug ${bugId} as an invalid test/spam submission?\n\n` +
-      'This will:\n' +
-      '  • Move the bug to Invalid Bugs :: General\n' +
-      '  • Resolve it as INVALID\n' +
-      '  • Clear needinfo flags\n' +
-      '  • Mark the reporter\'s comments as spam\n' +
-      '  • Post a warning comment\n\n' +
-      'This cannot be undone easily. Continue?'
-    );
+    const { confirmed, markAsSpam } = await showCloseDialog(bugId);
     if (!confirmed) return;
 
     btn.disabled = true;
@@ -31,7 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       await Bugzilla.API.post(
         `invalid_bug_helper/close/${bugId}`,
-        {}
+        { mark_as_spam: markAsSpam ? 1 : 0 }
       );
       window.location.replace(
         `${BUGZILLA.config.basepath}show_bug.cgi?id=${bugId}`

--- a/extensions/InvalidBugHelper/web/js/invalid_bug_helper.js
+++ b/extensions/InvalidBugHelper/web/js/invalid_bug_helper.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0. */
+
+'use strict';
+
+(() => {
+  const btn = document.getElementById('close-as-invalid-btn');
+  if (!btn) return;
+
+  btn.addEventListener('click', async () => {
+    const bugId = BUGZILLA.bug_id;
+    const confirmed = window.confirm(
+      `Close Bug ${bugId} as an invalid test/spam submission?\n\n` +
+      'This will:\n' +
+      '  • Move the bug to Invalid Bugs :: General\n' +
+      '  • Resolve it as INVALID\n' +
+      '  • Clear needinfo flags\n' +
+      '  • Mark the reporter\'s comments as spam\n' +
+      '  • Post a warning comment\n\n' +
+      'This cannot be undone easily. Continue?'
+    );
+    if (!confirmed) return;
+
+    btn.disabled = true;
+    btn.textContent = 'Closing…';
+
+    try {
+      await Bugzilla.API.post(
+        `invalid_bug_helper/close/${bugId}`,
+        {}
+      );
+      window.location.replace(
+        `${BUGZILLA.config.basepath}show_bug.cgi?id=${bugId}`
+      );
+    } catch (err) {
+      const message = (err && err.message) ? err.message : String(err);
+      window.alert(`Failed to close bug: ${message}`);
+      btn.disabled = false;
+      btn.textContent = 'Close as Invalid';
+    }
+  });
+})();

--- a/extensions/InvalidBugHelper/web/js/invalid_bug_helper.js
+++ b/extensions/InvalidBugHelper/web/js/invalid_bug_helper.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-(() => {
+document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('close-as-invalid-btn');
   if (!btn) return;
 
@@ -43,4 +43,4 @@
       btn.textContent = 'Close as Invalid';
     }
   });
-})();
+}, { once: true });

--- a/extensions/InvalidBugHelper/web/styles/invalid_bug_helper.css
+++ b/extensions/InvalidBugHelper/web/styles/invalid_bug_helper.css
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0. */
+
+#close-invalid-dialog {
+  max-width: 28em;
+  padding: 16px;
+  border: 1px solid var(--primary-region-border-color);
+  border-radius: var(--primary-region-border-radius);
+  background: var(--primary-region-background-color);
+}
+
+#close-invalid-dialog h3 {
+  margin-top: 0;
+  font-size: var(--font-size-h3);
+}
+
+#close-invalid-dialog label {
+  cursor: pointer;
+}
+
+#close-invalid-dialog .warning-icon {
+  font-size: 1.4em;
+  line-height: 1;
+}
+
+#close-invalid-dialog .warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin: 0.5em 0 1em;
+  padding: 8px;
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+  border-radius: var(--primary-region-border-radius);
+  color: #664d03;
+}
+
+#close-invalid-dialog .actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}

--- a/t/bmo/invalid-bug-helper.t
+++ b/t/bmo/invalid-bug-helper.t
@@ -1,0 +1,51 @@
+#!/usr/bin/env perl
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+use strict;
+use warnings;
+use 5.10.1;
+use lib qw( . lib local/lib/perl5 );
+
+BEGIN {
+  $ENV{LOG4PERL_CONFIG_FILE}     = 'log4perl-t.conf';
+  $ENV{BUGZILLA_DISABLE_HOSTAGE} = 1;
+}
+
+use Test::More;
+
+# Load Bugzilla::Extension to install the INC_HOOK that maps
+# Bugzilla::Extension::NAME::* to extensions/NAME/lib/*.
+use_ok('Bugzilla::Extension');
+
+# The INC_HOOK maps Bugzilla::Extension::InvalidBugHelper::* to
+# extensions/InvalidBugHelper/lib/*.
+use_ok('Bugzilla::Extension::InvalidBugHelper::WebService');
+use_ok('Bugzilla::Extension::InvalidBugHelper::Config');
+
+# Verify rest_resources returns the expected REST route.
+my $resources = Bugzilla::Extension::InvalidBugHelper::WebService->rest_resources;
+ok(ref $resources eq 'ARRAY', 'rest_resources returns an arrayref');
+ok(scalar(@$resources) == 2, 'rest_resources has two elements (pattern + handler)');
+
+my ($pattern, $handlers) = @$resources;
+ok(ref $pattern eq 'Regexp', 'first element is a regex');
+ok(exists $handlers->{POST}, 'handler defines a POST method');
+ok($handlers->{POST}{method} eq 'close_as_invalid',
+  'POST handler maps to close_as_invalid');
+
+# Verify PUBLIC_METHODS includes close_as_invalid.
+my @public = Bugzilla::Extension::InvalidBugHelper::WebService->PUBLIC_METHODS;
+ok(grep({ $_ eq 'close_as_invalid' } @public),
+  'close_as_invalid is in PUBLIC_METHODS');
+
+# Verify Config returns the expected params.
+my @params = Bugzilla::Extension::InvalidBugHelper::Config->get_param_list;
+my %param_names = map { $_->{name} => 1 } @params;
+ok($param_names{invalidbughelper_warning_text}, 'warning_text param defined');
+
+done_testing();

--- a/t/bmo/invalid-bug-helper.t
+++ b/t/bmo/invalid-bug-helper.t
@@ -38,6 +38,17 @@ ok(exists $handlers->{POST}, 'handler defines a POST method');
 ok($handlers->{POST}{method} eq 'close_as_invalid',
   'POST handler maps to close_as_invalid');
 
+# Verify the route regex matches valid bug IDs and rejects invalid ones.
+ok('/invalid_bug_helper/close/123' =~ $pattern, 'route matches numeric bug id');
+ok('/invalid_bug_helper/close/0' =~ $pattern,   'route matches bug id 0');
+ok('/invalid_bug_helper/close/abc' !~ $pattern,  'route rejects non-numeric id');
+ok('/invalid_bug_helper/close/' !~ $pattern,     'route rejects missing id');
+
+# Verify the params sub extracts bug_id from the capture group.
+my $params_sub = $handlers->{POST}{params};
+is(ref $params_sub, 'CODE', 'params is a code ref');
+is_deeply($params_sub->(42), {bug_id => 42}, 'params sub extracts bug_id');
+
 # Verify PUBLIC_METHODS includes close_as_invalid.
 my @public = Bugzilla::Extension::InvalidBugHelper::WebService->PUBLIC_METHODS;
 ok(grep({ $_ eq 'close_as_invalid' } @public),


### PR DESCRIPTION
## Summary:
- New InvalidBugHelper extension that adds a "Close as Invalid" button to the bug modal
- Moves the bug to the "Invalid Bugs" product, resolves as INVALID, clears needinfo flags and strips security groups (all in one click)
- Spam-tagging the reporter's comments is opt-in via a checkbox in the confirmation dialog, with a warning message to avoid accidentally auto-disabling legitimate accounts
- Configurable warning comment posted to the reporter, editable via Administration > Parameters > Invalid Bug Helper
- Button visibility checks: editbugs group, product access and mandatory security group membership
- Server-side validation mirrors template checks: rejects already-resolved/verified bugs, enforces mandatory group membership and snapshots groups before the product move

## Test plan:
- Verify button appears on open bugs for users with editbugs + access to "Invalid Bugs" product + membership in mandatory security groups
- Verify button appears even when comment_taggers_group param is unset
- Verify button is hidden on RESOLVED/VERIFIED bugs and bugs already in "Invalid Bugs"
- Verify button is hidden for users without sufficient permissions
- Verify clicking the button with spam checkbox unchecked moves the bug and resolves it but does not tag comments as spam
- Verify clicking the button with spam checkbox checked moves the bug, resolves it and tags the reporter's comments as spam
- Verify security groups are stripped using the pre-move snapshot (not the post-move group list)
- Verify API rejects calls on already-resolved/verified bugs and bugs already in "Invalid Bugs"
- Verify API rejects calls from users who are not members of mandatory security groups on the bug
- Run t/bmo/invalid-bug-helper.t