### PR TITLE
Bug 1726931 - Add "All Reported by You" query to My Dashboard

### DIFF
--- a/extensions/MyDashboard/lib/Queries.pm
+++ b/extensions/MyDashboard/lib/Queries.pm
@@ -91,6 +91,16 @@ sub QUERY_DEFS {
       }
     },
     {
+      name        => 'reportedbugs',
+      heading     => 'All Reported by You',
+      description => 'All bugs you reported, including resolved and closed ones.',
+      params      => {
+        'emailreporter1' => 1,
+        'emailtype1'     => 'exact',
+        'email1'         => $user->login
+      }
+    },
+    {
       name        => 'openccbugs',
       heading     => "You Are CC'd On",
       description => 'You are in the CC list of the bug, so you are watching it.',

--- a/extensions/MyDashboard/lib/Queries.pm
+++ b/extensions/MyDashboard/lib/Queries.pm
@@ -93,7 +93,7 @@ sub QUERY_DEFS {
     {
       name        => 'reportedbugs',
       heading     => 'All Reported by You',
-      description => 'All bugs you reported, including resolved and closed ones.',
+      description => 'All bugs you reported, both open and closed ones.',
       params      => {
         'emailreporter1' => 1,
         'emailtype1'     => 'exact',

--- a/extensions/MyDashboard/web/js/query.js
+++ b/extensions/MyDashboard/web/js/query.js
@@ -202,8 +202,17 @@ window.addEventListener('DOMContentLoaded', () => {
     }
   };
 
-  // Initial load
-  updateQueryTable(default_query);
+  // Initial load — fall back to reportedbugs if assignedbugs is empty
+  // and no saved preference exists (helps new users with no assigned bugs).
+  updateQueryTable(default_query).then(() => {
+    if (default_query === 'assignedbugs' && !query && bugQueryTable.data.length === 0) {
+      const $option = document.querySelector('#query option[value="reportedbugs"]');
+      if ($option) {
+        $option.selected = true;
+        updateQueryTable('reportedbugs');
+      }
+    }
+  });
   auto_updateQueryTable();
 
   document.querySelector('#query').addEventListener('change', (e) => {

--- a/extensions/MyDashboard/web/js/query.js
+++ b/extensions/MyDashboard/web/js/query.js
@@ -209,6 +209,7 @@ window.addEventListener('DOMContentLoaded', () => {
       const $option = document.querySelector('#query option[value="reportedbugs"]');
       if ($option) {
         $option.selected = true;
+        default_query = 'reportedbugs';
         updateQueryTable('reportedbugs');
       }
     }


### PR DESCRIPTION
## Summary
- Add a new "reportedbugs" query in the My Dashboard dropdown listing all bugs reported by the user, regardless of status (open, resolved, closed)
- Auto-fallback: when "Assigned to You" returns no results and the user has no saved query preference, the dashboard switches to "All Reported by You" so new users see their bugs instead of an empty list

## Test plan
- Select "All Reported by You" in the dropdown - verify it shows all reported bugs including resolved/closed ones
- Log in as a user with no assigned bugs and no saved dashboard preference - verify the dashboard falls back to "All Reported by You"
- Log in as a user with assigned bugs - verify the dashboard stays on "Assigned to You"
- Select a query manually, reload - verify the saved preference is respected and no fallback occurs
