### PR TITLE
Bug 2052429 - Show: Open/Closed/All selects All incorrectly

### DIFF
--- a/buglist.cgi
+++ b/buglist.cgi
@@ -29,7 +29,7 @@ use Bugzilla::Status;
 use Bugzilla::Token;
 
 use Date::Parse;
-use List::Util qw(any);
+use List::Util qw(any all);
 use List::MoreUtils qw(uniq);
 
 
@@ -890,9 +890,21 @@ $vars->{'closedstates'} = [map { $_->name } closed_bug_statuses()];
 
 # Determine which status filter tab is active for the toggle UI.
 {
-  my @requested = $params->param('bug_status');
+  my @requested   = $params->param('bug_status');
+  my @resolution  = $params->param('resolution');
   if (!@requested || any { $_ eq '__all__' } @requested) {
-    $vars->{'status_filter'} = 'all';
+    # resolution=--- (unresolved) only matches open bugs; a resolution list
+    # with no "---" only matches closed bugs. Either way that's a more
+    # specific filter than "all", even though bug_status wasn't set.
+    if (@resolution && all { $_ eq '---' } @resolution) {
+      $vars->{'status_filter'} = 'open';
+    }
+    elsif (@resolution && !(any { $_ eq '---' } @resolution)) {
+      $vars->{'status_filter'} = 'closed';
+    }
+    else {
+      $vars->{'status_filter'} = 'all';
+    }
   }
   elsif (any { $_ eq '__open__' } @requested) {
     $vars->{'status_filter'} = 'open';


### PR DESCRIPTION
## Summary
The status toggle on the search results page ("Show: Open/Closed/All") only looked at `bug_status` to decide which tab is active. A search filtered only by `resolution` (e.g. `resolution=---` for unresolved, or a real resolution like `FIXED`) left `bug_status` unset, so the toggle always fell back to "All" even though the results were effectively open-only or closed-only.

This adds a `resolution`-based fallback, used only when `bug_status` doesn't already pin down open/closed/all:
- `resolution=---` only → **Open**
- one or more real resolutions, no `---` → **Closed**
- mix of `---` and real resolutions, or no resolution filter → **All** (unchanged)

## Test plan
- `resolution=---` alone → Open tab active
- `resolution=FIXED` alone → Closed tab active
- `resolution=---&resolution=FIXED` → All tab active (unchanged)
- no `bug_status`/`resolution` → All tab active (unchanged)
- explicit `bug_status=__open__` → Open tab active (unaffected)

Verified against a local docker instance.