### PR TITLE
Bug 2053269 - BMO API bugzilla.login helper needs to support Bugzilla_api_token + cookie for authentication support

### DIFF
--- a/Bugzilla/App/Plugin/Login.pm
+++ b/Bugzilla/App/Plugin/Login.pm
@@ -10,6 +10,8 @@ use 5.10.1;
 use Mojo::Base 'Mojolicious::Plugin';
 
 use Bugzilla::Constants;
+use Bugzilla::Error;
+use Bugzilla::Token;
 use Bugzilla::User::APIKey;
 use Bugzilla::Util qw(with_writable_database);
 
@@ -52,9 +54,36 @@ sub register {
 
       # Try cookies first if we are using the web UI
       my $usage_mode = Bugzilla->usage_mode;
-      if ($usage_mode == USAGE_MODE_BROWSER || $usage_mode == USAGE_MODE_MOJO) {
+      if ( $usage_mode == USAGE_MODE_BROWSER
+        || $usage_mode == USAGE_MODE_MOJO
+        || $usage_mode == USAGE_MODE_MOJO_REST)
+      {
         my $login_cookie  = $c->cookie("Bugzilla_logincookie");
         my $login_user_id = $c->cookie("Bugzilla_login");
+
+        # For REST API requests, cookie authentication additionally requires a
+        # valid Bugzilla_api_token which acts as a CSRF token. This mirrors the
+        # legacy WebService flow in Bugzilla::Auth::Login::Cookie.
+        if ($usage_mode == USAGE_MODE_MOJO_REST) {
+          if (defined(my $api_token = $c->param('Bugzilla_api_token'))) {
+            my ($token_user_id, undef, undef, $token_type)
+              = Bugzilla::Token::GetTokenData($api_token);
+            if ( !defined $token_type
+              || $token_type ne 'api_token'
+              || !$login_user_id
+              || $login_user_id != $token_user_id)
+            {
+              Bugzilla->check_rate_limit('token_mismatch');
+              ThrowUserError('auth_invalid_token', {token => $api_token});
+            }
+          }
+          elsif ($login_cookie) {
+
+            # REST requires an api-token when using cookie authentication;
+            # fall back to a non-authenticated request.
+            $login_cookie = '';
+          }
+        }
 
         if ($login_cookie && $login_user_id) {
           my $db_cookie

--- a/qa/t/rest_native_login.t
+++ b/qa/t/rest_native_login.t
@@ -84,7 +84,8 @@ $t->post_ok(
 # value here also confirms the browser login above succeeded.
 $t->get_ok($url . 'home')->status_is(200);
 my $global = $t->tx->res->dom->at('#bugzilla-global');
-my $bugzilla_config = $global ? decode_json($global->{'data-bugzilla'}) : {};
+my $bugzilla_json = $global ? $global->attr('data-bugzilla') : undef;
+my $bugzilla_config = $bugzilla_json ? decode_json($bugzilla_json) : {};
 my $api_token = $bugzilla_config->{api_token};
 ok($api_token, 'Logged in and obtained a Bugzilla_api_token');
 

--- a/qa/t/rest_native_login.t
+++ b/qa/t/rest_native_login.t
@@ -1,0 +1,104 @@
+#!/usr/bin/env perl
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+# Exercises authentication for native (Mojolicious) REST endpoints, which
+# authenticate through the bugzilla.login helper (Bugzilla::App::Plugin::Login)
+# rather than the legacy WebService stack. In particular this verifies that,
+# in addition to the X-Bugzilla-API-Key header, the helper accepts the web UI's
+# login cookie + Bugzilla_api_token parameter (used by Bugzilla.API in
+# JavaScript). A login-required endpoint is used purely as a vehicle; its own
+# behaviour is not under test.
+
+use strict;
+use warnings;
+use 5.10.1;
+use lib qw(lib ../../lib ../../local/lib/perl5);
+
+use Bugzilla;
+
+use QA::Util qw(get_config);
+use Mojo::JSON qw(decode_json);
+use Test::Mojo;
+use Test::More;
+
+my $config   = get_config();
+my $url      = Bugzilla->localconfig->urlbase;
+my $api_key  = $config->{admin_user_api_key};
+my $login    = $config->{admin_user_login};
+my $password = $config->{admin_user_passwd};
+
+# A native Mojo REST endpoint that requires the user to be logged in.
+my $endpoint = 'rest/search/needinfo_last_seen?days=30';
+
+my $t = Test::Mojo->new();
+$t->ua->max_redirects(3);
+
+#
+# 1. Unauthenticated requests are rejected.
+#
+$t->get_ok($url . $endpoint)->status_is(401);
+
+#
+# 2. Authentication via an API key in the X-Bugzilla-API-Key header works.
+#
+$t->get_ok($url . $endpoint => {'X-Bugzilla-API-Key' => $api_key})
+  ->status_is(200)->json_has('/result');
+
+#
+# 3. Authentication via the login cookie + Bugzilla_api_token parameter works.
+#    This is the mechanism the web UI (Bugzilla.API) uses, and is the path that
+#    native Mojo REST endpoints previously rejected with a 401.
+#
+
+# Perform a browser login so the user agent's cookie jar holds valid
+# Bugzilla_login and Bugzilla_logincookie cookies.
+
+# The first request seeds the Bugzilla_login_request_cookie (anti-CSRF) cookie.
+$t->get_ok($url . 'home')->status_is(200);
+
+# The second request now carries that cookie, so the rendered login form
+# contains a matching Bugzilla_login_token.
+$t->get_ok($url . 'home')->status_is(200);
+my $token_input
+  = $t->tx->res->dom->at('input[name="Bugzilla_login_token"]');
+my $login_token = $token_input ? $token_input->{value} : '';
+ok($login_token, 'Obtained a login request token');
+
+# Submit the login form (the /login route maps to index.cgi?GoAheadAndLogIn=1).
+$t->post_ok(
+  $url . 'login' => form => {
+    Bugzilla_login       => $login,
+    Bugzilla_password    => $password,
+    Bugzilla_login_token => $login_token,
+  }
+)->status_is(200);
+
+# Fetch a page and read the Bugzilla_api_token from the embedded page config
+# (the #bugzilla-global element's data-bugzilla attribute holds JSON).
+# get_api_token() only emits a token when a user is logged in, so a non-empty
+# value here also confirms the browser login above succeeded.
+$t->get_ok($url . 'home')->status_is(200);
+my $global = $t->tx->res->dom->at('#bugzilla-global');
+my $bugzilla_config = $global ? decode_json($global->{'data-bugzilla'}) : {};
+my $api_token = $bugzilla_config->{api_token};
+ok($api_token, 'Logged in and obtained a Bugzilla_api_token');
+
+# 3a. Login cookie + a valid Bugzilla_api_token authenticates the request.
+$t->get_ok($url . $endpoint . '&Bugzilla_api_token=' . $api_token)
+  ->status_is(200)->json_has('/result');
+
+# 3b. The login cookie alone (no api-token) is not sufficient for a REST
+#     request; the api-token acts as a required CSRF guard.
+$t->get_ok($url . $endpoint)->status_is(401);
+
+# 3c. Supplying an invalid Bugzilla_api_token is rejected as a bad request
+#     (auth_invalid_token) rather than silently falling back to anonymous.
+$t->get_ok($url . $endpoint . '&Bugzilla_api_token=invalid-token-value')
+  ->status_is(400);
+
+done_testing();

--- a/qa/t/rest_native_login.t
+++ b/qa/t/rest_native_login.t
@@ -102,4 +102,12 @@ $t->get_ok($url . $endpoint)->status_is(401);
 $t->get_ok($url . $endpoint . '&Bugzilla_api_token=invalid-token-value')
   ->status_is(400);
 
+# 3d. A valid Bugzilla_api_token WITHOUT the matching login cookie must not
+#     authenticate. A leaked/stolen token is useless on its own; it is only
+#     honoured alongside the session cookie it belongs to. Use a fresh user
+#     agent so no login cookies are sent.
+my $t_no_cookie = Test::Mojo->new();
+$t_no_cookie->get_ok($url . $endpoint . '&Bugzilla_api_token=' . $api_token)
+  ->status_is(400);
+
 done_testing();


### PR DESCRIPTION
Bug 2043733's native Mojo REST endpoint authenticates via the bugzilla.login helper (Bugzilla::App::Plugin::Login), which didn't understand the web UI's Bugzilla_api_token mechanism — so browser-originated requests (login cookie + Bugzilla_api_token query param, as sent by Bugzilla.API in JS) got a 401.

Fix — Bugzilla/App/Plugin/Login.pm

- Added use Bugzilla::Error; and use Bugzilla::Token;.
- Extended the cookie branch to also handle USAGE_MODE_MOJO_REST, mirroring the legacy Bugzilla::Auth::Login::Cookie (56-78):
  - If a Bugzilla_api_token param is present, validate it via GetTokenData — it must be an api_token whose userid matches the login cookie's user, else rate-limit + ThrowUserError('auth_invalid_token').
  - Login cookie present but no api-token → clear the cookie (REST requires the token as a CSRF guard), falling back to unauthenticated.
  - Valid cookie + token then flows through the existing DB cookie verification.

ThrowUserError works here because MOJO_REST sets ERROR_MODE_MOJO, which stashes the error and lets the app render it as JSON.

New test — qa/t/rest_native_login.t

A generic auth test (not tied to any feature) that drives a login-required native-Mojo REST endpoint (rest/search/needinfo_last_seen) and verifies all four paths: no-auth → 401, X-Bugzilla-API-Key header → 200, browser login cookie + Bugzilla_api_token → 200, cookie-without-token → 401, and invalid token → 400. It performs a real browser login over HTTP and reads the token from the page's #bugzilla-global config.