### PR TITLE
Bug 2053330 - Close as Invalid button jumps next to Save Changes when a Resolve as button is clicked

### DIFF
--- a/extensions/BugModal/web/bug_modal.js
+++ b/extensions/BugModal/web/bug_modal.js
@@ -1211,6 +1211,7 @@ $(function() {
             $('#bottom-resolution').val($(event.target).text()).change();
             $('#top-save-btn').show();
             $('#resolve-as').hide();
+            $('#close-as-invalid-btn').hide();
             $('#bottom-status').show();
             if ($('#bottom-dup_id').is(":visible")) {
                 $('#bottom-dup_id').focus();
@@ -1225,6 +1226,7 @@ $(function() {
             $('#bug_status').val($(event.target).data('status')).change();
             $('#top-save-btn').show();
             $('#resolve-as').hide();
+            $('#close-as-invalid-btn').hide();
             $('#bottom-status').show();
             if ($('#bottom-dup_id').is(":visible")) {
                 $('#bottom-dup_id').focus();


### PR DESCRIPTION
## Summary
Clicking a "Resolve as" button hide `#resolve-as` but left `#close-as-invalid-btn` visible, so it collapsed leftward next to "Save Changes".
Now `#close-as-invalid-btn` is hidden alongside `#resolve-as` in both the resolution-btn and status-btn click handlers.

## Test plan
- Open a bug in the local docker instance, click a "Resolve as" button, confirm "Close and move to Invalid Bugs" no longer jumps next to "Save Changes"

Bugzilla link: [2053330](https://bugzilla.mozilla.org/show_bug.cgi?id=2053330)