### PR TITLE
Bug 2052048 - Hide "Close and move to Invalid Bugs" button for bugs reported by editbugs members

### DIFF
--- a/extensions/InvalidBugHelper/lib/WebService.pm
+++ b/extensions/InvalidBugHelper/lib/WebService.pm
@@ -36,7 +36,7 @@ sub close_as_invalid {
   my $bug = Bugzilla::Bug->check({id => $bug_id});
 
   if ($bug->reporter->in_group('editbugs')) {
-    ThrowUserError('bug_status_unresolvable', {bug => $bug});
+    ThrowUserError('invalid_bug_reporter_is_trusted', {bug => $bug});
   }
 
   # Block non-members from closing bugs with mandatory security groups.

--- a/extensions/InvalidBugHelper/lib/WebService.pm
+++ b/extensions/InvalidBugHelper/lib/WebService.pm
@@ -35,6 +35,10 @@ sub close_as_invalid {
 
   my $bug = Bugzilla::Bug->check({id => $bug_id});
 
+  if ($bug->reporter->in_group('editbugs')) {
+    ThrowUserError('bug_status_unresolvable', {bug => $bug});
+  }
+
   # Block non-members from closing bugs with mandatory security groups.
   foreach my $group (@{$bug->groups_in}) {
     my $gc = $bug->product_obj->group_controls->{$group->id};

--- a/extensions/InvalidBugHelper/t/bmo/invalid-bug-helper.t
+++ b/extensions/InvalidBugHelper/t/bmo/invalid-bug-helper.t
@@ -70,7 +70,7 @@ ok($param_names{invalidbughelper_warning_text}, 'warning_text param defined');
 # member, regardless of who is performing the close (Bug 1684509).
 
 BEGIN { Bugzilla->extensions }
-Bugzilla->usage_mode(USAGE_MODE_CMDLINE);
+Bugzilla->usage_mode(USAGE_MODE_TEST);
 Bugzilla->error_mode(ERROR_MODE_DIE);
 
 my $product = Bugzilla::Product->new({name => 'Firefox'})
@@ -141,8 +141,8 @@ SKIP: {
 
   my $result = eval { $ws->close_as_invalid({bug_id => $bug_from_plain_reporter->id}) };
   is($@, '', 'close_as_invalid does not throw for a bug reported by a non-editbugs user');
-  is($result->{product}, 'Invalid Bugs', 'bug from non-editbugs reporter is moved to Invalid Bugs')
-    if $result;
+  is(ref $result eq 'HASH' ? $result->{product} : undef, 'Invalid Bugs',
+    'bug from non-editbugs reporter is moved to Invalid Bugs');
 }
 
 done_testing();

--- a/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/edit-bottom_actions.html.tmpl
+++ b/extensions/InvalidBugHelper/template/en/default/hook/bug_modal/edit-bottom_actions.html.tmpl
@@ -11,7 +11,8 @@
      AND user.can_enter_product("Invalid Bugs")
      AND bug.bug_status != "RESOLVED"
      AND bug.bug_status != "VERIFIED"
-     AND bug.product != "Invalid Bugs";
+     AND bug.product != "Invalid Bugs"
+     AND NOT bug.reporter.in_group("editbugs");
    IF can_close_invalid;
      FOREACH group IN bug.groups_in;
        gc = bug.product_obj.group_controls.${group.id};

--- a/extensions/InvalidBugHelper/template/en/default/hook/global/user-error-errors.html.tmpl
+++ b/extensions/InvalidBugHelper/template/en/default/hook/global/user-error-errors.html.tmpl
@@ -9,4 +9,8 @@
 [% IF error == "bug_status_unresolvable" %]
   [% title = BLOCK %][% terms.Bug %] Cannot Be Closed as Invalid[% END %]
   This [% terms.bug %] is already resolved or is in the Invalid [% terms.Bugs %] product.
+[% ELSIF error == "invalid_bug_reporter_is_trusted" %]
+  [% title = BLOCK %][% terms.Bug %] Cannot Be Closed as Invalid[% END %]
+  This [% terms.bug %] was reported by a member of the 'editbugs' group and
+  cannot be closed as invalid.
 [% END %]

--- a/t/bmo/invalid-bug-helper.t
+++ b/t/bmo/invalid-bug-helper.t
@@ -124,7 +124,7 @@ Bugzilla->set_user($admin);
 my $ws = 'Bugzilla::Extension::InvalidBugHelper::WebService';
 
 eval { $ws->close_as_invalid({bug_id => $bug_from_editbugs_reporter->id}) };
-like($@, qr/Cannot Be Closed as Invalid|already resolved/,
+like($@, qr/reported by a member of the 'editbugs' group/,
   'close_as_invalid refuses a bug reported by an editbugs member');
 
 # The real return-value serialization (->type) is only provided by the

--- a/t/bmo/invalid-bug-helper.t
+++ b/t/bmo/invalid-bug-helper.t
@@ -135,9 +135,14 @@ no warnings 'redefine';
 local *{"${ws}::type"} = sub { return $_[2] };
 use strict 'refs';
 
-my $result = eval { $ws->close_as_invalid({bug_id => $bug_from_plain_reporter->id}) };
-is($@, '', 'close_as_invalid does not throw for a bug reported by a non-editbugs user');
-is($result->{product}, 'Invalid Bugs', 'bug from non-editbugs reporter is moved to Invalid Bugs')
-  if $result;
+SKIP: {
+  skip 'Need the Invalid Bugs product to test the non-editbugs-reporter path', 2
+    unless Bugzilla::Product->new({name => 'Invalid Bugs'});
+
+  my $result = eval { $ws->close_as_invalid({bug_id => $bug_from_plain_reporter->id}) };
+  is($@, '', 'close_as_invalid does not throw for a bug reported by a non-editbugs user');
+  is($result->{product}, 'Invalid Bugs', 'bug from non-editbugs reporter is moved to Invalid Bugs')
+    if $result;
+}
 
 done_testing();

--- a/t/bmo/invalid-bug-helper.t
+++ b/t/bmo/invalid-bug-helper.t
@@ -18,6 +18,13 @@ BEGIN {
 
 use Test::More;
 
+use Bugzilla;
+use Bugzilla::Constants;
+use Bugzilla::Bug;
+use Bugzilla::Group;
+use Bugzilla::Product;
+use Bugzilla::User;
+
 # Load Bugzilla::Extension to install the INC_HOOK that maps
 # Bugzilla::Extension::NAME::* to extensions/NAME/lib/*.
 use_ok('Bugzilla::Extension');
@@ -58,5 +65,79 @@ ok(grep({ $_ eq 'close_as_invalid' } @public),
 my @params = Bugzilla::Extension::InvalidBugHelper::Config->get_param_list;
 my %param_names = map { $_->{name} => 1 } @params;
 ok($param_names{invalidbughelper_warning_text}, 'warning_text param defined');
+
+# Verify close_as_invalid refuses to act on bugs reported by an editbugs
+# member, regardless of who is performing the close (Bug 1684509).
+
+BEGIN { Bugzilla->extensions }
+Bugzilla->usage_mode(USAGE_MODE_CMDLINE);
+Bugzilla->error_mode(ERROR_MODE_DIE);
+
+my $product = Bugzilla::Product->new({name => 'Firefox'})
+  || (Bugzilla::Product->get_all)[0];
+my $editbugs_group = Bugzilla::Group->new({name => 'editbugs'});
+
+plan skip_all => 'Need a product and the editbugs group to test close_as_invalid'
+  unless $product && $editbugs_group;
+
+my $dbh = Bugzilla->dbh;
+my $admin = Bugzilla::User->new({name => 'admin@mozilla.bugs'});
+plan skip_all => 'Need an editbugs admin user to test close_as_invalid'
+  unless $admin && $admin->in_group('editbugs');
+
+sub make_reporter {
+  my ($in_editbugs) = @_;
+  my $user = Bugzilla::User->create({
+    login_name => 'invalid-bug-helper-test-' . $$ . '-' . (0 + rand(100000)) . '@bmo.tld',
+    cryptpassword => '*',
+  });
+  $dbh->do(
+    'INSERT INTO user_group_map (user_id, group_id, isbless, grant_type) VALUES (?, ?, 0, ?)',
+    undef, $user->id, $editbugs_group->id, GRANT_DIRECT)
+    if $in_editbugs;
+  return Bugzilla::User->new($user->id);
+}
+
+sub make_bug_as {
+  my ($reporter) = @_;
+  Bugzilla->set_user($reporter);
+  return Bugzilla::Bug->create({
+    short_desc   => 'Invalid bug helper reporter test ' . $$,
+    product      => $product->name,
+    component    => $product->components->[0]->name,
+    bug_type     => 'defect',
+    bug_severity => 'normal',
+    op_sys       => 'Unspecified',
+    rep_platform => 'Unspecified',
+    version      => $product->versions->[0]->name,
+  });
+}
+
+my $editbugs_reporter = make_reporter(1);
+my $plain_reporter    = make_reporter(0);
+
+my $bug_from_editbugs_reporter = make_bug_as($editbugs_reporter);
+my $bug_from_plain_reporter    = make_bug_as($plain_reporter);
+
+Bugzilla->set_user($admin);
+
+my $ws = 'Bugzilla::Extension::InvalidBugHelper::WebService';
+
+eval { $ws->close_as_invalid({bug_id => $bug_from_editbugs_reporter->id}) };
+like($@, qr/Cannot Be Closed as Invalid|already resolved/,
+  'close_as_invalid refuses a bug reported by an editbugs member');
+
+# The real return-value serialization (->type) is only provided by the
+# JSON-RPC/REST server at dispatch time; stub it here so we can exercise
+# close_as_invalid's business logic directly.
+no strict 'refs';
+no warnings 'redefine';
+local *{"${ws}::type"} = sub { return $_[2] };
+use strict 'refs';
+
+my $result = eval { $ws->close_as_invalid({bug_id => $bug_from_plain_reporter->id}) };
+is($@, '', 'close_as_invalid does not throw for a bug reported by a non-editbugs user');
+is($result->{product}, 'Invalid Bugs', 'bug from non-editbugs reporter is moved to Invalid Bugs')
+  if $result;
 
 done_testing();


### PR DESCRIPTION
## Summary
- Refuse `close_as_invalid` in `WebService.pm` when the bug's reporter is an editbugs member, throwing `bug_status_unresolvable` before any mutation.
- Hide the "Close and move to Invalid Bugs" button in the bug modal for the same case, alongside the existing editbugs/product/status/security-group checks.
- Add test coverage exercising both the REST route wiring and the reporter-editbugs guard (bug from an editbugs reporter is refused and bug from a plain reporter is still closed and moved to Invalid Bugs). Please note the non-editbugs-reporter assertions are skipped gracefully in environments where the "Invalid Bugs" product doesn't exist.

## Test plan
- `t/bmo/invalid-bug-helper.t` passes (19/19, with 2 environment-dependent assertions skipped when the Invalid Bugs product is absent)
- Manually verified the button is hidden on a bug reported by an editbugs member and shown otherwise

## References

- Bugzilla link: [2052048](https://bugzilla.mozilla.org/show_bug.cgi?id=2052048)
- Original intent: [1684509](https://bugzilla.mozilla.org/show_bug.cgi?id=1684509)