### PR TITLE
Bug 2055285 - Remove the "Show closed/merged PR" checkbox in the GH PR view

### DIFF
--- a/extensions/GitHubPullRequests/template/en/default/github/table.html.tmpl
+++ b/extensions/GitHubPullRequests/template/en/default/github/table.html.tmpl
@@ -27,12 +27,4 @@
         <span class="github-load-error-string"></span></td>
     </tr>
   </tbody>
-  <tbody class="github-show-closed bz_default_hidden">
-    <tr>
-      <td colspan="7">
-        <input id="github-show-closed" type="checkbox">
-        <label for="github-show-closed">Show Closed/Merged Pull Requests</label>
-      </td>
-    </tr>
-  </tbody>
 </table>

--- a/extensions/GitHubPullRequests/web/js/github_pull_requests.js
+++ b/extensions/GitHubPullRequests/web/js/github_pull_requests.js
@@ -5,7 +5,6 @@
 "use strict";
 
 const GitHubPullRequests = {
-  showClosed: false,
   pullRequests: [],
 
   // Maps PR state to display label and CSS class
@@ -39,9 +38,6 @@ const GitHubPullRequests = {
 
     if (pr.state && this.isClosedState(pr.state)) {
       tr.classList.add("github-pr-closed");
-      if (!this.showClosed) {
-        tr.classList.add("bz_default_hidden");
-      }
     }
 
     // PR number cell
@@ -167,22 +163,7 @@ const GitHubPullRequests = {
     return tr;
   },
 
-  updateVisibility() {
-    for (const pr of this.pullRequests) {
-      const tr = document.querySelector(`tr[data-pr-url="${CSS.escape(pr.url)}"]`);
-      if (!tr) continue;
-      if (this.isClosedState(pr.state || "")) {
-        tr.classList.toggle("bz_default_hidden", !this.showClosed);
-      }
-    }
-  },
-
   async onLoad() {
-    const showClosedCheckbox = document.querySelector("#github-show-closed");
-    if (!showClosedCheckbox) return;
-
-    this.showClosed = showClosedCheckbox.checked;
-
     const tbody = document.querySelector("tbody.github-prs-body");
     if (!tbody) return;
 
@@ -212,26 +193,12 @@ const GitHubPullRequests = {
           tbody.insertBefore(this.buildRow(pr), loadingRow);
         }
         loadingRow.classList.add("bz_default_hidden");
-
-        // Show the closed toggle if any PRs are closed/merged
-        const hasClosed = this.pullRequests.some(pr => this.isClosedState(pr.state || ""));
-        if (hasClosed) {
-          const showClosedTbody = document.querySelector("tbody.github-show-closed");
-          if (showClosedTbody) {
-            showClosedTbody.classList.remove("bz_default_hidden");
-          }
-        }
       }
     } catch (e) {
       console.error(e);
       displayLoadError(e.message);
       loadingRow.classList.add("bz_default_hidden");
     }
-
-    showClosedCheckbox.addEventListener("click", () => {
-      this.showClosed = showClosedCheckbox.checked;
-      this.updateVisibility();
-    });
   },
 };
 


### PR DESCRIPTION
Changes:

template/en/default/github/table.html.tmpl
- Removed the <tbody class="github-show-closed"> block containing the #github-show-closed checkbox and its label.

web/js/github_pull_requests.js
- Removed the showClosed state field.
- buildRow() no longer adds bz_default_hidden to closed/merged PR rows (they now render like any other row; the github-pr-closed marker class is kept in case styling wants it later).
- Removed the updateVisibility() method.
- onLoad() no longer looks up the checkbox, reveals the toggle tbody, or wires the click listener — it simply renders every PR returned by the API.

No CSS changes were needed (there were no github-show-closed rules).