### PR TITLE
Bug 2056682 - Need to add Net::CIDR dependency to the base BMO perl image

### DIFF
--- a/Dockerfile.bmo-slim
+++ b/Dockerfile.bmo-slim
@@ -1,4 +1,6 @@
-FROM perl:5.40.0-slim AS builder
+FROM perl:5.44.0-slim AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -33,9 +35,9 @@ RUN apt-file update \
     | xargs -IFILE apt-file search -l FILE \
     | sort -u > PACKAGES
 
-FROM perl:5.40.0-slim
+FROM perl:5.44.0-slim
 
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 COPY --from=builder /app/local /app/local
 COPY --from=builder /app/PACKAGES /app/PACKAGES

--- a/Dockerfile.cpanfile
+++ b/Dockerfile.cpanfile
@@ -1,11 +1,13 @@
-FROM perl:5.40.0-slim
+FROM perl:5.44.0-slim
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y \
     build-essential curl libssl-dev zlib1g-dev openssl \
     libexpat-dev cmake git libcairo-dev libgd-dev \
-    default-libmysqlclient-dev unzip wget
+    default-libmysqlclient-dev unzip wget libgmp-dev
 RUN cpanm --notest --quiet App::cpm Module::CPANfile Carton::Snapshot
 
 WORKDIR /app
@@ -13,8 +15,18 @@ WORKDIR /app
 COPY Makefile.PL Bugzilla.pm gen-cpanfile.pl /app/
 COPY extensions/ /app/extensions/
 
-RUN perl Makefile.PL
-RUN make cpanfile
+RUN perl Makefile.PL \
+    && make cpanfile
+
+# Bug #133363 for Crypt-DES: Crypt::DES fails to build with Xcode 12 [rt.cpan.org #133363]
+# https://rt.cpan.org/Public/Bug/Display.html?id=133363
+RUN ccflags=$(perl -MConfig -e 'print qq{$Config{ccflags} -Wno-implicit-function-declaration};'); \
+    cpanm -L local -n -v --configure-args="ccflags='$ccflags'" Crypt::DES
+
+# Bug #149108 for Net-IDN-Encode: [PATCH] use uvchr_to_utf8_flags instead of uvuni_to_utf8_flags (which is removed in perl 5.38.0)
+# https://rt.cpan.org/Public/Bug/Display.html?id=149108
+RUN cpanm -L local --notest --no-wget --from https://cpan.metacpan.org/ \
+    https://cpan.metacpan.org/authors/id/E/ET/ETHER/Net-IDN-Encode-2.501-TRIAL.tar.gz
 
 RUN carton install
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -88,6 +88,7 @@ my %requires = (
   'Moo'                                 => '2.002004',
   'MooX::StrictConstructor'             => '0.008',
   'Mozilla::CA'                         => '20160104',
+  'Net::CIDR'                           => '0',
   'Net::DNS'                            => '0',
   'Package::Stash'                      => '0.37',
   'Parse::CPAN::Meta'                   => '1.44',

--- a/cpanfile
+++ b/cpanfile
@@ -89,6 +89,7 @@ requires 'Mojolicious::Plugin::OAuth2::Server', '0.44';
 requires 'Moo', '2.002004';
 requires 'MooX::StrictConstructor', '0.008';
 requires 'Mozilla::CA', '20160104';
+requires 'Net::CIDR';
 requires 'Net::DNS';
 requires 'Net::SMTP::TLS';
 requires 'Package::Stash', '0.37';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -42,7 +42,9 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       MIME::Base64 0
       Math::BigInt 1.78
+      Math::BigInt::GMP 0
       Math::Prime::Util 0.64
+      Math::Prime::Util::GMP 0
       Sort::Versions 0
       Test::More 0.45
       Tie::EncryptedHash 0
@@ -150,10 +152,10 @@ DISTRIBUTIONS
       IO::Seekable 0
       Time::Local 0
       perl 5.006
-  Auth-GoogleAuth-1.09
-    pathname: G/GR/GRYPHON/Auth-GoogleAuth-1.09.tar.gz
+  Auth-GoogleAuth-1.10
+    pathname: G/GR/GRYPHON/Auth-GoogleAuth-1.10.tar.gz
     provides:
-      Auth::GoogleAuth 1.09
+      Auth::GoogleAuth 1.10
     requirements:
       Carp 0
       Class::Accessor 0
@@ -166,22 +168,22 @@ DISTRIBUTIONS
       perl 5.010
       strict 0
       warnings 0
-  Authen-SASL-2.1900
-    pathname: E/EH/EHUELS/Authen-SASL-2.1900.tar.gz
+  Authen-SASL-2.2000
+    pathname: E/EH/EHUELS/Authen-SASL-2.2000.tar.gz
     provides:
-      Authen::SASL 2.1900
-      Authen::SASL::CRAM_MD5 2.1900
-      Authen::SASL::EXTERNAL 2.1900
-      Authen::SASL::Perl 2.1900
-      Authen::SASL::Perl::ANONYMOUS 2.1900
-      Authen::SASL::Perl::CRAM_MD5 2.1900
-      Authen::SASL::Perl::DIGEST_MD5 2.1900
-      Authen::SASL::Perl::EXTERNAL 2.1900
-      Authen::SASL::Perl::GSSAPI 2.1900
-      Authen::SASL::Perl::LOGIN 2.1900
-      Authen::SASL::Perl::OAUTHBEARER 2.1900
-      Authen::SASL::Perl::PLAIN 2.1900
-      Authen::SASL::Perl::XOAUTH2 2.1900
+      Authen::SASL 2.2000
+      Authen::SASL::CRAM_MD5 2.2000
+      Authen::SASL::EXTERNAL 2.2000
+      Authen::SASL::Perl 2.2000
+      Authen::SASL::Perl::ANONYMOUS 2.2000
+      Authen::SASL::Perl::CRAM_MD5 2.2000
+      Authen::SASL::Perl::DIGEST_MD5 2.2000
+      Authen::SASL::Perl::EXTERNAL 2.2000
+      Authen::SASL::Perl::GSSAPI 2.2000
+      Authen::SASL::Perl::LOGIN 2.2000
+      Authen::SASL::Perl::OAUTHBEARER 2.2000
+      Authen::SASL::Perl::PLAIN 2.2000
+      Authen::SASL::Perl::XOAUTH2 2.2000
     requirements:
       Crypt::URandom 0
       Digest::HMAC_MD5 0
@@ -244,19 +246,19 @@ DISTRIBUTIONS
       Scalar::Util 1.21
       Test::More 0.98
       perl 5.006000
-  CGI-4.71
-    pathname: L/LE/LEEJO/CGI-4.71.tar.gz
+  CGI-4.72
+    pathname: L/LE/LEEJO/CGI-4.72.tar.gz
     provides:
-      CGI 4.71
-      CGI::Carp 4.71
+      CGI 4.72
+      CGI::Carp 4.72
       CGI::Cookie 4.59
-      CGI::File::Temp 4.71
+      CGI::File::Temp 4.72
       CGI::HTML::Functions undef
-      CGI::MultipartBuffer 4.71
-      CGI::Pretty 4.71
-      CGI::Push 4.71
-      CGI::Util 4.71
-      Fh 4.71
+      CGI::MultipartBuffer 4.72
+      CGI::Pretty 4.72
+      CGI::Push 4.72
+      CGI::Util 4.72
+      Fh 4.72
     requirements:
       Carp 0
       Config 0
@@ -514,13 +516,6 @@ DISTRIBUTIONS
       Class::Data::Inheritable 0.10
     requirements:
       ExtUtils::MakeMaker 0
-  Class-ErrorHandler-0.04
-    pathname: T/TO/TOKUHIROM/Class-ErrorHandler-0.04.tar.gz
-    provides:
-      Class::ErrorHandler 0.04
-    requirements:
-      ExtUtils::MakeMaker 0
-      perl 5.008_001
   Class-Inspector-1.36
     pathname: P/PL/PLICEASE/Class-Inspector-1.36.tar.gz
     provides:
@@ -622,10 +617,10 @@ DISTRIBUTIONS
       Time::HiRes 0
       XSLoader 0
       perl 5.008
-  Clone-0.47
-    pathname: A/AT/ATOOMIC/Clone-0.47.tar.gz
+  Clone-0.50
+    pathname: A/AT/ATOOMIC/Clone-0.50.tar.gz
     provides:
-      Clone 0.47
+      Clone 0.50
     requirements:
       ExtUtils::MakeMaker 0
   Clone-Choose-0.010
@@ -740,12 +735,6 @@ DISTRIBUTIONS
       Digest::MD5 0
       ExtUtils::MakeMaker 0
       MIME::Base64 0
-  Convert-ASN1-0.34
-    pathname: T/TI/TIMLEGGE/Convert-ASN1-0.34.tar.gz
-    provides:
-      Convert::ASN1 0.34
-    requirements:
-      ExtUtils::MakeMaker 0
   Convert-Base32-0.06
     pathname: I/IK/IKEGAMI/Convert-Base32-0.06.tar.gz
     provides:
@@ -754,19 +743,6 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test::Exception 0
       Test::More 0
-  Convert-PEM-0.13
-    pathname: T/TI/TIMLEGGE/Convert-PEM-0.13.tar.gz
-    provides:
-      Convert::PEM 0.13
-      Convert::PEM::CBC 0.13
-    requirements:
-      Class::ErrorHandler 0
-      Convert::ASN1 0.34
-      Crypt::DES_EDE3 0
-      Crypt::PRNG 0
-      Digest::MD5 0
-      ExtUtils::MakeMaker 0
-      MIME::Base64 0
   Cookie-Baker-0.12
     pathname: K/KA/KAZEBURO/Cookie-Baker-0.12.tar.gz
     provides:
@@ -776,10 +752,10 @@ DISTRIBUTIONS
       Module::Build::Tiny 0.035
       URI::Escape 0
       perl 5.008001
-  Cpanel-JSON-XS-4.40
-    pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.40.tar.gz
+  Cpanel-JSON-XS-4.43
+    pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.43.tar.gz
     provides:
-      Cpanel::JSON::XS 4.40
+      Cpanel::JSON::XS 4.43
       Cpanel::JSON::XS::Type undef
     requirements:
       Carp 0
@@ -792,13 +768,12 @@ DISTRIBUTIONS
       overload 0
       strict 0
       warnings 0
-  Crypt-Argon2-0.030
-    pathname: L/LE/LEONT/Crypt-Argon2-0.030.tar.gz
+  Crypt-Argon2-0.031
+    pathname: L/LE/LEONT/Crypt-Argon2-0.031.tar.gz
     provides:
-      Crypt::Argon2 0.030
+      Crypt::Argon2 0.031
     requirements:
-      Dist::Build 0.020
-      Dist::Build::Core 0
+      Dist::Build 0.028
       Dist::Build::XS 0
       Dist::Build::XS::Conf 0
       Exporter 5.57
@@ -851,30 +826,30 @@ DISTRIBUTIONS
     requirements:
       Crypt::DES 0
       ExtUtils::MakeMaker 0
-  Crypt-DSA-1.19
-    pathname: T/TI/TIMLEGGE/Crypt-DSA-1.19.tar.gz
+  Crypt-DSA-GMP-0.02
+    pathname: D/DA/DANAJ/Crypt-DSA-GMP-0.02.tar.gz
     provides:
-      BufferWithInt 1.19
-      Crypt::DSA 1.19
-      Crypt::DSA::Key 1.19
-      Crypt::DSA::Key::PEM 1.19
-      Crypt::DSA::Key::SSH2 1.19
-      Crypt::DSA::KeyChain 1.19
-      Crypt::DSA::Signature 1.19
-      Crypt::DSA::Util 1.19
+      Crypt::DSA::GMP 0.02
+      Crypt::DSA::GMP::Key 0.01
+      Crypt::DSA::GMP::Key::PEM 0.01
+      Crypt::DSA::GMP::Key::SSH2 0.01
+      Crypt::DSA::GMP::KeyChain 0.01
+      Crypt::DSA::GMP::Signature 0.01
+      Crypt::DSA::GMP::Util 0.01
     requirements:
-      Convert::ASN1 0
-      Convert::PEM 0.13
-      Crypt::URandom 0
-      Data::Buffer 0.01
-      Digest::SHA 0
-      ExtUtils::MakeMaker 6.42
-      File::Spec 0
-      File::Which 0.05
-      IPC::Open3 0
+      Carp 0
+      Crypt::Random::Seed 0
+      Data::Buffer 0.04
+      Digest::SHA 5.22
+      Exporter 5.562
+      ExtUtils::MakeMaker 0
       MIME::Base64 0
       Math::BigInt 1.78
-      perl 5.006
+      Math::BigInt::GMP 0
+      Math::Prime::Util::GMP 0.15
+      Test::More 0.45
+      base 0
+      perl 5.006002
   Crypt-IDEA-1.10
     pathname: D/DP/DPARIS/Crypt-IDEA-1.10.tar.gz
     provides:
@@ -882,13 +857,13 @@ DISTRIBUTIONS
       IDEA 1.10
     requirements:
       ExtUtils::MakeMaker 0
-  Crypt-JWT-0.037
-    pathname: M/MI/MIK/Crypt-JWT-0.037.tar.gz
+  Crypt-JWT-0.038
+    pathname: M/MI/MIK/Crypt-JWT-0.038.tar.gz
     provides:
-      Crypt::JWT 0.037
-      Crypt::KeyWrap 0.037
+      Crypt::JWT 0.038
+      Crypt::KeyWrap 0.038
     requirements:
-      Compress::Raw::Zlib 0
+      Compress::Raw::Zlib 2.057
       CryptX 0.067
       Exporter 5.57
       ExtUtils::MakeMaker 0
@@ -896,72 +871,72 @@ DISTRIBUTIONS
       Scalar::Util 0
       Test::More 0.88
       perl 5.006
-  Crypt-OpenPGP-1.19
-    pathname: T/TI/TIMLEGGE/Crypt-OpenPGP-1.19.tar.gz
+  Crypt-OpenPGP-1.21
+    pathname: T/TI/TIMLEGGE/Crypt-OpenPGP-1.21.tar.gz
     provides:
-      Crypt::OpenPGP 1.19
-      Crypt::OpenPGP::Armour 1.19
-      Crypt::OpenPGP::Buffer 1.19
-      Crypt::OpenPGP::CFB 1.19
-      Crypt::OpenPGP::Certificate 1.19
-      Crypt::OpenPGP::Cipher 1.19
-      Crypt::OpenPGP::Cipher::Blowfish 1.19
-      Crypt::OpenPGP::Cipher::CAST5 1.19
-      Crypt::OpenPGP::Cipher::DES3 1.19
-      Crypt::OpenPGP::Cipher::IDEA 1.19
-      Crypt::OpenPGP::Cipher::Rijndael 1.19
-      Crypt::OpenPGP::Cipher::Rijndael192 1.19
-      Crypt::OpenPGP::Cipher::Rijndael256 1.19
-      Crypt::OpenPGP::Cipher::Twofish 1.19
-      Crypt::OpenPGP::Ciphertext 1.19
-      Crypt::OpenPGP::Compressed 1.19
-      Crypt::OpenPGP::Config 1.19
-      Crypt::OpenPGP::Config::GnuPG 1.19
-      Crypt::OpenPGP::Config::PGP2 1.19
-      Crypt::OpenPGP::Config::PGP5 1.19
-      Crypt::OpenPGP::Constants 1.19
-      Crypt::OpenPGP::Digest 1.19
-      Crypt::OpenPGP::Digest::MD5 1.19
-      Crypt::OpenPGP::Digest::RIPEMD160 1.19
-      Crypt::OpenPGP::Digest::SHA1 1.19
-      Crypt::OpenPGP::Digest::SHA224 1.19
-      Crypt::OpenPGP::Digest::SHA256 1.19
-      Crypt::OpenPGP::Digest::SHA384 1.19
-      Crypt::OpenPGP::Digest::SHA512 1.19
-      Crypt::OpenPGP::ElGamal::Private 1.19
-      Crypt::OpenPGP::ElGamal::Public 1.19
-      Crypt::OpenPGP::ErrorHandler 1.19
-      Crypt::OpenPGP::Key 1.19
-      Crypt::OpenPGP::Key::Public 1.19
-      Crypt::OpenPGP::Key::Public::DSA 1.19
-      Crypt::OpenPGP::Key::Public::ElGamal 1.19
-      Crypt::OpenPGP::Key::Public::RSA 1.19
-      Crypt::OpenPGP::Key::Secret 1.19
-      Crypt::OpenPGP::Key::Secret::DSA 1.19
-      Crypt::OpenPGP::Key::Secret::ElGamal 1.19
-      Crypt::OpenPGP::Key::Secret::RSA 1.19
-      Crypt::OpenPGP::KeyBlock 1.19
-      Crypt::OpenPGP::KeyRing 1.19
-      Crypt::OpenPGP::KeyServer 1.19
-      Crypt::OpenPGP::MDC 1.19
-      Crypt::OpenPGP::Marker 1.19
-      Crypt::OpenPGP::Message 1.19
-      Crypt::OpenPGP::OnePassSig 1.19
-      Crypt::OpenPGP::PacketFactory 1.19
-      Crypt::OpenPGP::Plaintext 1.19
-      Crypt::OpenPGP::S2k 1.19
-      Crypt::OpenPGP::S2k::Salt_Iter 1.19
-      Crypt::OpenPGP::S2k::Salted 1.19
-      Crypt::OpenPGP::S2k::Simple 1.19
-      Crypt::OpenPGP::SKSessionKey 1.19
-      Crypt::OpenPGP::SessionKey 1.19
-      Crypt::OpenPGP::Signature 1.19
-      Crypt::OpenPGP::Signature::SubPacket 1.19
-      Crypt::OpenPGP::Trust 1.19
-      Crypt::OpenPGP::UserAttribute 1.19
-      Crypt::OpenPGP::UserID 1.19
-      Crypt::OpenPGP::Util 1.19
-      Crypt::OpenPGP::Words 1.19
+      Crypt::OpenPGP 1.21
+      Crypt::OpenPGP::Armour 1.21
+      Crypt::OpenPGP::Buffer 1.21
+      Crypt::OpenPGP::CFB 1.21
+      Crypt::OpenPGP::Certificate 1.21
+      Crypt::OpenPGP::Cipher 1.21
+      Crypt::OpenPGP::Cipher::Blowfish 1.21
+      Crypt::OpenPGP::Cipher::CAST5 1.21
+      Crypt::OpenPGP::Cipher::DES3 1.21
+      Crypt::OpenPGP::Cipher::IDEA 1.21
+      Crypt::OpenPGP::Cipher::Rijndael 1.21
+      Crypt::OpenPGP::Cipher::Rijndael192 1.21
+      Crypt::OpenPGP::Cipher::Rijndael256 1.21
+      Crypt::OpenPGP::Cipher::Twofish 1.21
+      Crypt::OpenPGP::Ciphertext 1.21
+      Crypt::OpenPGP::Compressed 1.21
+      Crypt::OpenPGP::Config 1.21
+      Crypt::OpenPGP::Config::GnuPG 1.21
+      Crypt::OpenPGP::Config::PGP2 1.21
+      Crypt::OpenPGP::Config::PGP5 1.21
+      Crypt::OpenPGP::Constants 1.21
+      Crypt::OpenPGP::Digest 1.21
+      Crypt::OpenPGP::Digest::MD5 1.21
+      Crypt::OpenPGP::Digest::RIPEMD160 1.21
+      Crypt::OpenPGP::Digest::SHA1 1.21
+      Crypt::OpenPGP::Digest::SHA224 1.21
+      Crypt::OpenPGP::Digest::SHA256 1.21
+      Crypt::OpenPGP::Digest::SHA384 1.21
+      Crypt::OpenPGP::Digest::SHA512 1.21
+      Crypt::OpenPGP::ElGamal::Private 1.21
+      Crypt::OpenPGP::ElGamal::Public 1.21
+      Crypt::OpenPGP::ErrorHandler 1.21
+      Crypt::OpenPGP::Key 1.21
+      Crypt::OpenPGP::Key::Public 1.21
+      Crypt::OpenPGP::Key::Public::DSA 1.21
+      Crypt::OpenPGP::Key::Public::ElGamal 1.21
+      Crypt::OpenPGP::Key::Public::RSA 1.21
+      Crypt::OpenPGP::Key::Secret 1.21
+      Crypt::OpenPGP::Key::Secret::DSA 1.21
+      Crypt::OpenPGP::Key::Secret::ElGamal 1.21
+      Crypt::OpenPGP::Key::Secret::RSA 1.21
+      Crypt::OpenPGP::KeyBlock 1.21
+      Crypt::OpenPGP::KeyRing 1.21
+      Crypt::OpenPGP::KeyServer 1.21
+      Crypt::OpenPGP::MDC 1.21
+      Crypt::OpenPGP::Marker 1.21
+      Crypt::OpenPGP::Message 1.21
+      Crypt::OpenPGP::OnePassSig 1.21
+      Crypt::OpenPGP::PacketFactory 1.21
+      Crypt::OpenPGP::Plaintext 1.21
+      Crypt::OpenPGP::S2k 1.21
+      Crypt::OpenPGP::S2k::Salt_Iter 1.21
+      Crypt::OpenPGP::S2k::Salted 1.21
+      Crypt::OpenPGP::S2k::Simple 1.21
+      Crypt::OpenPGP::SKSessionKey 1.21
+      Crypt::OpenPGP::SessionKey 1.21
+      Crypt::OpenPGP::Signature 1.21
+      Crypt::OpenPGP::Signature::SubPacket 1.21
+      Crypt::OpenPGP::Trust 1.21
+      Crypt::OpenPGP::UserAttribute 1.21
+      Crypt::OpenPGP::UserID 1.21
+      Crypt::OpenPGP::Util 1.21
+      Crypt::OpenPGP::Words 1.21
     requirements:
       Alt::Crypt::RSA::BigInt 0
       Bytes::Random::Secure 0
@@ -969,7 +944,7 @@ DISTRIBUTIONS
       Crypt::Blowfish 0
       Crypt::CAST5_PP 0
       Crypt::DES_EDE3 0
-      Crypt::DSA 1.17
+      Crypt::DSA::GMP 0.02
       Crypt::IDEA 0
       Crypt::RIPEMD160 0.05
       Crypt::Rijndael 0
@@ -977,12 +952,15 @@ DISTRIBUTIONS
       Data::Buffer 0.04
       Digest::MD5 0
       Digest::SHA 0
+      Exporter 5.57
       ExtUtils::MakeMaker 0
       File::HomeDir 0
       LWP::UserAgent 0
       MIME::Base64 0
       Math::BigInt 0
       URI::Escape 0
+      parent 0
+      perl 5.008001
   Crypt-OpenSSL-Bignum-0.09
     pathname: K/KM/KMX/Crypt-OpenSSL-Bignum-0.09.tar.gz
     provides:
@@ -1002,14 +980,15 @@ DISTRIBUTIONS
       File::Spec 0
       Symbol 0
       perl 5.008001
-  Crypt-OpenSSL-RSA-0.37
-    pathname: T/TO/TODDR/Crypt-OpenSSL-RSA-0.37.tar.gz
+  Crypt-OpenSSL-RSA-0.41
+    pathname: T/TI/TIMLEGGE/Crypt-OpenSSL-RSA-0.41.tar.gz
     provides:
-      Crypt::OpenSSL::RSA 0.37
+      Crypt::OpenSSL::RSA 0.41
     requirements:
+      Crypt::OpenSSL::Bignum 0
+      Crypt::OpenSSL::Guess 0.11
       Crypt::OpenSSL::Random 0
       ExtUtils::MakeMaker 0
-      Test::More 0
       perl 5.006
   Crypt-OpenSSL-Random-0.17
     pathname: R/RU/RURBAN/Crypt-OpenSSL-Random-0.17.tar.gz
@@ -1018,23 +997,24 @@ DISTRIBUTIONS
     requirements:
       Crypt::OpenSSL::Guess 0.11
       ExtUtils::MakeMaker 0
-  Crypt-PBKDF2-0.161520
-    pathname: A/AR/ARODLAND/Crypt-PBKDF2-0.161520.tar.gz
+  Crypt-PBKDF2-0.261630
+    pathname: A/AR/ARODLAND/Crypt-PBKDF2-0.261630.tar.gz
     provides:
-      Crypt::PBKDF2 0.161520
-      Crypt::PBKDF2::Hash 0.161520
-      Crypt::PBKDF2::Hash::DigestHMAC 0.161520
-      Crypt::PBKDF2::Hash::HMACSHA1 0.161520
-      Crypt::PBKDF2::Hash::HMACSHA2 0.161520
-      Crypt::PBKDF2::Hash::HMACSHA3 0.161520
+      Crypt::PBKDF2 0.261630
+      Crypt::PBKDF2::Hash 0.261630
+      Crypt::PBKDF2::Hash::DigestHMAC 0.261630
+      Crypt::PBKDF2::Hash::HMACSHA1 0.261630
+      Crypt::PBKDF2::Hash::HMACSHA2 0.261630
+      Crypt::PBKDF2::Hash::HMACSHA3 0.261630
     requirements:
       Carp 0
+      Crypt::URandom 0
       Digest 1.16
       Digest::HMAC 1.01
       Digest::SHA 0
       Digest::SHA3 0.22
-      ExtUtils::MakeMaker 0
       MIME::Base64 0
+      Module::Build::Tiny 0.034
       Module::Runtime 0
       Moo 2
       Moo::Role 2
@@ -1044,14 +1024,15 @@ DISTRIBUTIONS
       Types::Standard 1.000005
       namespace::autoclean 0
       strictures 2
-  Crypt-RIPEMD160-0.08
-    pathname: T/TO/TODDR/Crypt-RIPEMD160-0.08.tar.gz
+  Crypt-RIPEMD160-0.14
+    pathname: T/TO/TODDR/Crypt-RIPEMD160-0.14.tar.gz
     provides:
-      Crypt::RIPEMD160 0.08
-      Crypt::RIPEMD160::MAC 0.08
+      Crypt::RIPEMD160 0.14
+      Crypt::RIPEMD160::MAC 0.14
     requirements:
       ExtUtils::MakeMaker 0
-      Test::More 0
+      XSLoader 0
+      perl 5.010
   Crypt-Random-Seed-0.03
     pathname: D/DA/DANAJ/Crypt-Random-Seed-0.03.tar.gz
     provides:
@@ -1087,10 +1068,10 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.006
-  Crypt-SMIME-0.31
-    pathname: M/MI/MIKAGE/Crypt-SMIME-0.31.tar.gz
+  Crypt-SMIME-0.33
+    pathname: M/MI/MIKAGE/Crypt-SMIME-0.33.tar.gz
     provides:
-      Crypt::SMIME 0.31
+      Crypt::SMIME 0.32
     requirements:
       ExtUtils::CChecker 0
       ExtUtils::Constant 0.23
@@ -1106,10 +1087,10 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       strict 0
-  Crypt-URandom-0.54
-    pathname: D/DD/DDICK/Crypt-URandom-0.54.tar.gz
+  Crypt-URandom-0.55
+    pathname: D/DD/DDICK/Crypt-URandom-0.55.tar.gz
     provides:
-      Crypt::URandom 0.54
+      Crypt::URandom 0.55
     requirements:
       Carp 1.26
       English 0
@@ -1118,130 +1099,145 @@ DISTRIBUTIONS
       FileHandle 0
       constant 0
       perl 5.006
-  CryptX-0.087
-    pathname: M/MI/MIK/CryptX-0.087.tar.gz
+  CryptX-0.090
+    pathname: M/MI/MIK/CryptX-0.090.tar.gz
     provides:
-      Crypt::AuthEnc 0.087
-      Crypt::AuthEnc::CCM 0.087
-      Crypt::AuthEnc::ChaCha20Poly1305 0.087
-      Crypt::AuthEnc::EAX 0.087
-      Crypt::AuthEnc::GCM 0.087
-      Crypt::AuthEnc::OCB 0.087
-      Crypt::Checksum 0.087
-      Crypt::Checksum::Adler32 0.087
-      Crypt::Checksum::CRC32 0.087
-      Crypt::Cipher 0.087
-      Crypt::Cipher::AES 0.087
-      Crypt::Cipher::Anubis 0.087
-      Crypt::Cipher::Blowfish 0.087
-      Crypt::Cipher::CAST5 0.087
-      Crypt::Cipher::Camellia 0.087
-      Crypt::Cipher::DES 0.087
-      Crypt::Cipher::DES_EDE 0.087
-      Crypt::Cipher::IDEA 0.087
-      Crypt::Cipher::KASUMI 0.087
-      Crypt::Cipher::Khazad 0.087
-      Crypt::Cipher::MULTI2 0.087
-      Crypt::Cipher::Noekeon 0.087
-      Crypt::Cipher::RC2 0.087
-      Crypt::Cipher::RC5 0.087
-      Crypt::Cipher::RC6 0.087
-      Crypt::Cipher::SAFERP 0.087
-      Crypt::Cipher::SAFER_K128 0.087
-      Crypt::Cipher::SAFER_K64 0.087
-      Crypt::Cipher::SAFER_SK128 0.087
-      Crypt::Cipher::SAFER_SK64 0.087
-      Crypt::Cipher::SEED 0.087
-      Crypt::Cipher::Serpent 0.087
-      Crypt::Cipher::Skipjack 0.087
-      Crypt::Cipher::Twofish 0.087
-      Crypt::Cipher::XTEA 0.087
-      Crypt::Digest 0.087
-      Crypt::Digest::BLAKE2b_160 0.087
-      Crypt::Digest::BLAKE2b_256 0.087
-      Crypt::Digest::BLAKE2b_384 0.087
-      Crypt::Digest::BLAKE2b_512 0.087
-      Crypt::Digest::BLAKE2s_128 0.087
-      Crypt::Digest::BLAKE2s_160 0.087
-      Crypt::Digest::BLAKE2s_224 0.087
-      Crypt::Digest::BLAKE2s_256 0.087
-      Crypt::Digest::CHAES 0.087
-      Crypt::Digest::Keccak224 0.087
-      Crypt::Digest::Keccak256 0.087
-      Crypt::Digest::Keccak384 0.087
-      Crypt::Digest::Keccak512 0.087
-      Crypt::Digest::MD2 0.087
-      Crypt::Digest::MD4 0.087
-      Crypt::Digest::MD5 0.087
-      Crypt::Digest::RIPEMD128 0.087
-      Crypt::Digest::RIPEMD160 0.087
-      Crypt::Digest::RIPEMD256 0.087
-      Crypt::Digest::RIPEMD320 0.087
-      Crypt::Digest::SHA1 0.087
-      Crypt::Digest::SHA224 0.087
-      Crypt::Digest::SHA256 0.087
-      Crypt::Digest::SHA384 0.087
-      Crypt::Digest::SHA3_224 0.087
-      Crypt::Digest::SHA3_256 0.087
-      Crypt::Digest::SHA3_384 0.087
-      Crypt::Digest::SHA3_512 0.087
-      Crypt::Digest::SHA512 0.087
-      Crypt::Digest::SHA512_224 0.087
-      Crypt::Digest::SHA512_256 0.087
-      Crypt::Digest::SHAKE 0.087
-      Crypt::Digest::Tiger192 0.087
-      Crypt::Digest::Whirlpool 0.087
-      Crypt::KeyDerivation 0.087
-      Crypt::Mac 0.087
-      Crypt::Mac::BLAKE2b 0.087
-      Crypt::Mac::BLAKE2s 0.087
-      Crypt::Mac::F9 0.087
-      Crypt::Mac::HMAC 0.087
-      Crypt::Mac::OMAC 0.087
-      Crypt::Mac::PMAC 0.087
-      Crypt::Mac::Pelican 0.087
-      Crypt::Mac::Poly1305 0.087
-      Crypt::Mac::XCBC 0.087
-      Crypt::Misc 0.087
-      Crypt::Mode 0.087
-      Crypt::Mode::CBC 0.087
-      Crypt::Mode::CFB 0.087
-      Crypt::Mode::CTR 0.087
-      Crypt::Mode::ECB 0.087
-      Crypt::Mode::OFB 0.087
-      Crypt::PK 0.087
-      Crypt::PK::DH 0.087
-      Crypt::PK::DSA 0.087
-      Crypt::PK::ECC 0.087
-      Crypt::PK::Ed25519 0.087
-      Crypt::PK::RSA 0.087
-      Crypt::PK::X25519 0.087
-      Crypt::PRNG 0.087
-      Crypt::PRNG::ChaCha20 0.087
-      Crypt::PRNG::Fortuna 0.087
-      Crypt::PRNG::RC4 0.087
-      Crypt::PRNG::Sober128 0.087
-      Crypt::PRNG::Yarrow 0.087
-      Crypt::Stream::ChaCha 0.087
-      Crypt::Stream::RC4 0.087
-      Crypt::Stream::Rabbit 0.087
-      Crypt::Stream::Salsa20 0.087
-      Crypt::Stream::Sober128 0.087
-      Crypt::Stream::Sosemanuk 0.087
-      CryptX 0.087
-      Math::BigInt::LTM 0.087
+      Crypt::ASN1 0.090
+      Crypt::AuthEnc 0.090
+      Crypt::AuthEnc::CCM 0.090
+      Crypt::AuthEnc::ChaCha20Poly1305 0.090
+      Crypt::AuthEnc::EAX 0.090
+      Crypt::AuthEnc::GCM 0.090
+      Crypt::AuthEnc::GCMSIV 0.090
+      Crypt::AuthEnc::OCB 0.090
+      Crypt::AuthEnc::SIV 0.090
+      Crypt::AuthEnc::XChaCha20Poly1305 0.090
+      Crypt::Checksum 0.090
+      Crypt::Checksum::Adler32 0.090
+      Crypt::Checksum::CRC32 0.090
+      Crypt::Cipher 0.090
+      Crypt::Cipher::AES 0.090
+      Crypt::Cipher::ARIA 0.090
+      Crypt::Cipher::Anubis 0.090
+      Crypt::Cipher::Blowfish 0.090
+      Crypt::Cipher::CAST5 0.090
+      Crypt::Cipher::Camellia 0.090
+      Crypt::Cipher::DES 0.090
+      Crypt::Cipher::DES_EDE 0.090
+      Crypt::Cipher::IDEA 0.090
+      Crypt::Cipher::KASUMI 0.090
+      Crypt::Cipher::Khazad 0.090
+      Crypt::Cipher::MULTI2 0.090
+      Crypt::Cipher::Noekeon 0.090
+      Crypt::Cipher::RC2 0.090
+      Crypt::Cipher::RC5 0.090
+      Crypt::Cipher::RC6 0.090
+      Crypt::Cipher::SAFERP 0.090
+      Crypt::Cipher::SAFER_K128 0.090
+      Crypt::Cipher::SAFER_K64 0.090
+      Crypt::Cipher::SAFER_SK128 0.090
+      Crypt::Cipher::SAFER_SK64 0.090
+      Crypt::Cipher::SEED 0.090
+      Crypt::Cipher::SM4 0.090
+      Crypt::Cipher::Serpent 0.090
+      Crypt::Cipher::Skipjack 0.090
+      Crypt::Cipher::Twofish 0.090
+      Crypt::Cipher::XTEA 0.090
+      Crypt::Digest 0.090
+      Crypt::Digest::BLAKE2b_160 0.090
+      Crypt::Digest::BLAKE2b_256 0.090
+      Crypt::Digest::BLAKE2b_384 0.090
+      Crypt::Digest::BLAKE2b_512 0.090
+      Crypt::Digest::BLAKE2s_128 0.090
+      Crypt::Digest::BLAKE2s_160 0.090
+      Crypt::Digest::BLAKE2s_224 0.090
+      Crypt::Digest::BLAKE2s_256 0.090
+      Crypt::Digest::CHAES 0.090
+      Crypt::Digest::KangarooTwelve 0.090
+      Crypt::Digest::Keccak224 0.090
+      Crypt::Digest::Keccak256 0.090
+      Crypt::Digest::Keccak384 0.090
+      Crypt::Digest::Keccak512 0.090
+      Crypt::Digest::MD2 0.090
+      Crypt::Digest::MD4 0.090
+      Crypt::Digest::MD5 0.090
+      Crypt::Digest::RIPEMD128 0.090
+      Crypt::Digest::RIPEMD160 0.090
+      Crypt::Digest::RIPEMD256 0.090
+      Crypt::Digest::RIPEMD320 0.090
+      Crypt::Digest::SHA1 0.090
+      Crypt::Digest::SHA224 0.090
+      Crypt::Digest::SHA256 0.090
+      Crypt::Digest::SHA384 0.090
+      Crypt::Digest::SHA3_224 0.090
+      Crypt::Digest::SHA3_256 0.090
+      Crypt::Digest::SHA3_384 0.090
+      Crypt::Digest::SHA3_512 0.090
+      Crypt::Digest::SHA512 0.090
+      Crypt::Digest::SHA512_224 0.090
+      Crypt::Digest::SHA512_256 0.090
+      Crypt::Digest::SHAKE 0.090
+      Crypt::Digest::SM3 0.090
+      Crypt::Digest::Tiger192 0.090
+      Crypt::Digest::TurboSHAKE 0.090
+      Crypt::Digest::Whirlpool 0.090
+      Crypt::KeyDerivation 0.090
+      Crypt::Mac 0.090
+      Crypt::Mac::BLAKE2b 0.090
+      Crypt::Mac::BLAKE2s 0.090
+      Crypt::Mac::F9 0.090
+      Crypt::Mac::HMAC 0.090
+      Crypt::Mac::KMAC 0.090
+      Crypt::Mac::OMAC 0.090
+      Crypt::Mac::PMAC 0.090
+      Crypt::Mac::Pelican 0.090
+      Crypt::Mac::Poly1305 0.090
+      Crypt::Mac::XCBC 0.090
+      Crypt::Misc 0.090
+      Crypt::Mode 0.090
+      Crypt::Mode::CBC 0.090
+      Crypt::Mode::CFB 0.090
+      Crypt::Mode::CTR 0.090
+      Crypt::Mode::ECB 0.090
+      Crypt::Mode::OFB 0.090
+      Crypt::PK 0.090
+      Crypt::PK::DH 0.090
+      Crypt::PK::DSA 0.090
+      Crypt::PK::ECC 0.090
+      Crypt::PK::Ed25519 0.090
+      Crypt::PK::Ed448 0.090
+      Crypt::PK::RSA 0.090
+      Crypt::PK::X25519 0.090
+      Crypt::PK::X448 0.090
+      Crypt::PRNG 0.090
+      Crypt::PRNG::ChaCha20 0.090
+      Crypt::PRNG::Fortuna 0.090
+      Crypt::PRNG::RC4 0.090
+      Crypt::PRNG::Sober128 0.090
+      Crypt::PRNG::Yarrow 0.090
+      Crypt::Stream::ChaCha 0.090
+      Crypt::Stream::RC4 0.090
+      Crypt::Stream::Rabbit 0.090
+      Crypt::Stream::Salsa20 0.090
+      Crypt::Stream::Sober128 0.090
+      Crypt::Stream::Sosemanuk 0.090
+      Crypt::Stream::XChaCha 0.090
+      Crypt::Stream::XSalsa20 0.090
+      CryptX 0.090
+      Math::BigInt::LTM 0.090
     requirements:
       ExtUtils::MakeMaker 0
       Math::BigInt 0
+      Time::HiRes 0
       perl 5.006
-  DBD-SQLite-1.76
-    pathname: I/IS/ISHIGAKI/DBD-SQLite-1.76.tar.gz
+  DBD-SQLite-1.78
+    pathname: I/IS/ISHIGAKI/DBD-SQLite-1.78.tar.gz
     provides:
-      DBD::SQLite 1.76
+      DBD::SQLite 1.78
       DBD::SQLite::Constants undef
       DBD::SQLite::GetInfo undef
-      DBD::SQLite::VirtualTable 1.76
-      DBD::SQLite::VirtualTable::Cursor 1.76
+      DBD::SQLite::VirtualTable 1.78
+      DBD::SQLite::VirtualTable::Cursor 1.78
       DBD::SQLite::VirtualTable::FileContent undef
       DBD::SQLite::VirtualTable::FileContent::Cursor undef
       DBD::SQLite::VirtualTable::PerlData undef
@@ -1268,8 +1264,8 @@ DISTRIBUTIONS
       Devel::CheckLib 1.09
       ExtUtils::MakeMaker 0
       perl 5.008001
-  DBI-1.647
-    pathname: H/HM/HMBRAND/DBI-1.647.tgz
+  DBI-1.651
+    pathname: H/HM/HMBRAND/DBI-1.651.tgz
     provides:
       Bundle::DBI 12.008696
       DBD::DBM 0.08
@@ -1282,15 +1278,15 @@ DISTRIBUTIONS
       DBD::ExampleP::db 12.014311
       DBD::ExampleP::dr 12.014311
       DBD::ExampleP::st 12.014311
-      DBD::File 0.44
-      DBD::File::DataSource::File 0.44
-      DBD::File::DataSource::Stream 0.44
-      DBD::File::Statement 0.44
-      DBD::File::Table 0.44
-      DBD::File::TableSource::FileSystem 0.44
-      DBD::File::db 0.44
-      DBD::File::dr 0.44
-      DBD::File::st 0.44
+      DBD::File 0.45
+      DBD::File::DataSource::File 0.45
+      DBD::File::DataSource::Stream 0.45
+      DBD::File::Statement 0.45
+      DBD::File::Table 0.45
+      DBD::File::TableSource::FileSystem 0.45
+      DBD::File::db 0.45
+      DBD::File::dr 0.45
+      DBD::File::st 0.45
       DBD::Gofer 0.015327
       DBD::Gofer::Policy::Base 0.010088
       DBD::Gofer::Policy::classic 0.010088
@@ -1325,7 +1321,7 @@ DISTRIBUTIONS
       DBD::Sponge::dr 12.010003
       DBD::Sponge::st 12.010003
       DBDI 12.015129
-      DBI 1.647
+      DBI 1.651
       DBI::Const::GetInfo::ANSI 2.008697
       DBI::Const::GetInfo::ODBC 2.011374
       DBI::Const::GetInfoReturn 2.008697
@@ -1365,10 +1361,11 @@ DISTRIBUTIONS
       DBI::SQL::Nano::Table_ 1.015544
       DBI::Util::CacheMemory 0.010315
       DBI::Util::_accessor 0.009479
-      DBI::common 1.647
+      DBI::common 1.651
     requirements:
       ExtUtils::MakeMaker 6.48
-      Test::Simple 0.90
+      Module::Load 0.22
+      Test::Simple 0.96
       perl 5.008001
   DBIx-Class-0.082844
     pathname: R/RI/RIBASUSHI/DBIx-Class-0.082844.tar.gz
@@ -1670,10 +1667,10 @@ DISTRIBUTIONS
       Exporter 0
       ExtUtils::MakeMaker 0
       perl 5.006
-  Data-ObjectDriver-0.26
-    pathname: S/SI/SIXAPART/Data-ObjectDriver-0.26.tar.gz
+  Data-ObjectDriver-0.27
+    pathname: S/SI/SIXAPART/Data-ObjectDriver-0.27.tar.gz
     provides:
-      Data::ObjectDriver 0.26
+      Data::ObjectDriver 0.27
       Data::ObjectDriver::BaseObject undef
       Data::ObjectDriver::BaseView undef
       Data::ObjectDriver::Driver::BaseCache undef
@@ -1709,7 +1706,7 @@ DISTRIBUTIONS
       List::Util 0
       Module::Build::Tiny 0.035
       Test::Exception 0
-      perl 5.006001
+      perl 5.008001
   Data-OptList-0.114
     pathname: R/RJ/RJBS/Data-OptList-0.114.tar.gz
     provides:
@@ -1732,6 +1729,29 @@ DISTRIBUTIONS
       Scalar::Util 1.01
       Storable 0
       perl 5.008
+  Data-Validate-Domain-0.15
+    pathname: D/DR/DROLSKY/Data-Validate-Domain-0.15.tar.gz
+    provides:
+      Data::Validate::Domain 0.15
+    requirements:
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Net::Domain::TLD 1.74
+      strict 0
+      warnings 0
+  Data-Validate-IP-0.31
+    pathname: D/DR/DROLSKY/Data-Validate-IP-0.31.tar.gz
+    provides:
+      Data::Validate::IP 0.31
+    requirements:
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      NetAddr::IP 4
+      Scalar::Util 0
+      base 0
+      perl 5.008
+      strict 0
+      warnings 0
   Data-Visitor-0.32
     pathname: E/ET/ETHER/Data-Visitor-0.32.tar.gz
     provides:
@@ -1840,11 +1860,11 @@ DISTRIBUTIONS
       DateTime::Format::Builder 0.6
       ExtUtils::MakeMaker 0
       perl 5.003
-  DateTime-Format-Strptime-1.79
-    pathname: D/DR/DROLSKY/DateTime-Format-Strptime-1.79.tar.gz
+  DateTime-Format-Strptime-1.80
+    pathname: D/DR/DROLSKY/DateTime-Format-Strptime-1.80.tar.gz
     provides:
-      DateTime::Format::Strptime 1.79
-      DateTime::Format::Strptime::Types 1.79
+      DateTime::Format::Strptime 1.80
+      DateTime::Format::Strptime::Types 1.80
     requirements:
       Carp 0
       DateTime 1.00
@@ -1903,335 +1923,335 @@ DISTRIBUTIONS
       Params::Validate 0
       Set::Infinite 0.59
       Test::More 0
-  DateTime-TimeZone-2.65
-    pathname: D/DR/DROLSKY/DateTime-TimeZone-2.65.tar.gz
+  DateTime-TimeZone-2.69
+    pathname: D/DR/DROLSKY/DateTime-TimeZone-2.69.tar.gz
     provides:
-      DateTime::TimeZone 2.65
-      DateTime::TimeZone::Africa::Abidjan 2.65
-      DateTime::TimeZone::Africa::Algiers 2.65
-      DateTime::TimeZone::Africa::Bissau 2.65
-      DateTime::TimeZone::Africa::Cairo 2.65
-      DateTime::TimeZone::Africa::Casablanca 2.65
-      DateTime::TimeZone::Africa::Ceuta 2.65
-      DateTime::TimeZone::Africa::El_Aaiun 2.65
-      DateTime::TimeZone::Africa::Johannesburg 2.65
-      DateTime::TimeZone::Africa::Juba 2.65
-      DateTime::TimeZone::Africa::Khartoum 2.65
-      DateTime::TimeZone::Africa::Lagos 2.65
-      DateTime::TimeZone::Africa::Maputo 2.65
-      DateTime::TimeZone::Africa::Monrovia 2.65
-      DateTime::TimeZone::Africa::Nairobi 2.65
-      DateTime::TimeZone::Africa::Ndjamena 2.65
-      DateTime::TimeZone::Africa::Sao_Tome 2.65
-      DateTime::TimeZone::Africa::Tripoli 2.65
-      DateTime::TimeZone::Africa::Tunis 2.65
-      DateTime::TimeZone::Africa::Windhoek 2.65
-      DateTime::TimeZone::America::Adak 2.65
-      DateTime::TimeZone::America::Anchorage 2.65
-      DateTime::TimeZone::America::Araguaina 2.65
-      DateTime::TimeZone::America::Argentina::Buenos_Aires 2.65
-      DateTime::TimeZone::America::Argentina::Catamarca 2.65
-      DateTime::TimeZone::America::Argentina::Cordoba 2.65
-      DateTime::TimeZone::America::Argentina::Jujuy 2.65
-      DateTime::TimeZone::America::Argentina::La_Rioja 2.65
-      DateTime::TimeZone::America::Argentina::Mendoza 2.65
-      DateTime::TimeZone::America::Argentina::Rio_Gallegos 2.65
-      DateTime::TimeZone::America::Argentina::Salta 2.65
-      DateTime::TimeZone::America::Argentina::San_Juan 2.65
-      DateTime::TimeZone::America::Argentina::San_Luis 2.65
-      DateTime::TimeZone::America::Argentina::Tucuman 2.65
-      DateTime::TimeZone::America::Argentina::Ushuaia 2.65
-      DateTime::TimeZone::America::Asuncion 2.65
-      DateTime::TimeZone::America::Bahia 2.65
-      DateTime::TimeZone::America::Bahia_Banderas 2.65
-      DateTime::TimeZone::America::Barbados 2.65
-      DateTime::TimeZone::America::Belem 2.65
-      DateTime::TimeZone::America::Belize 2.65
-      DateTime::TimeZone::America::Boa_Vista 2.65
-      DateTime::TimeZone::America::Bogota 2.65
-      DateTime::TimeZone::America::Boise 2.65
-      DateTime::TimeZone::America::Cambridge_Bay 2.65
-      DateTime::TimeZone::America::Campo_Grande 2.65
-      DateTime::TimeZone::America::Cancun 2.65
-      DateTime::TimeZone::America::Caracas 2.65
-      DateTime::TimeZone::America::Cayenne 2.65
-      DateTime::TimeZone::America::Chicago 2.65
-      DateTime::TimeZone::America::Chihuahua 2.65
-      DateTime::TimeZone::America::Ciudad_Juarez 2.65
-      DateTime::TimeZone::America::Costa_Rica 2.65
-      DateTime::TimeZone::America::Coyhaique 2.65
-      DateTime::TimeZone::America::Cuiaba 2.65
-      DateTime::TimeZone::America::Danmarkshavn 2.65
-      DateTime::TimeZone::America::Dawson 2.65
-      DateTime::TimeZone::America::Dawson_Creek 2.65
-      DateTime::TimeZone::America::Denver 2.65
-      DateTime::TimeZone::America::Detroit 2.65
-      DateTime::TimeZone::America::Edmonton 2.65
-      DateTime::TimeZone::America::Eirunepe 2.65
-      DateTime::TimeZone::America::El_Salvador 2.65
-      DateTime::TimeZone::America::Fort_Nelson 2.65
-      DateTime::TimeZone::America::Fortaleza 2.65
-      DateTime::TimeZone::America::Glace_Bay 2.65
-      DateTime::TimeZone::America::Goose_Bay 2.65
-      DateTime::TimeZone::America::Grand_Turk 2.65
-      DateTime::TimeZone::America::Guatemala 2.65
-      DateTime::TimeZone::America::Guayaquil 2.65
-      DateTime::TimeZone::America::Guyana 2.65
-      DateTime::TimeZone::America::Halifax 2.65
-      DateTime::TimeZone::America::Havana 2.65
-      DateTime::TimeZone::America::Hermosillo 2.65
-      DateTime::TimeZone::America::Indiana::Indianapolis 2.65
-      DateTime::TimeZone::America::Indiana::Knox 2.65
-      DateTime::TimeZone::America::Indiana::Marengo 2.65
-      DateTime::TimeZone::America::Indiana::Petersburg 2.65
-      DateTime::TimeZone::America::Indiana::Tell_City 2.65
-      DateTime::TimeZone::America::Indiana::Vevay 2.65
-      DateTime::TimeZone::America::Indiana::Vincennes 2.65
-      DateTime::TimeZone::America::Indiana::Winamac 2.65
-      DateTime::TimeZone::America::Inuvik 2.65
-      DateTime::TimeZone::America::Iqaluit 2.65
-      DateTime::TimeZone::America::Jamaica 2.65
-      DateTime::TimeZone::America::Juneau 2.65
-      DateTime::TimeZone::America::Kentucky::Louisville 2.65
-      DateTime::TimeZone::America::Kentucky::Monticello 2.65
-      DateTime::TimeZone::America::La_Paz 2.65
-      DateTime::TimeZone::America::Lima 2.65
-      DateTime::TimeZone::America::Los_Angeles 2.65
-      DateTime::TimeZone::America::Maceio 2.65
-      DateTime::TimeZone::America::Managua 2.65
-      DateTime::TimeZone::America::Manaus 2.65
-      DateTime::TimeZone::America::Martinique 2.65
-      DateTime::TimeZone::America::Matamoros 2.65
-      DateTime::TimeZone::America::Mazatlan 2.65
-      DateTime::TimeZone::America::Menominee 2.65
-      DateTime::TimeZone::America::Merida 2.65
-      DateTime::TimeZone::America::Metlakatla 2.65
-      DateTime::TimeZone::America::Mexico_City 2.65
-      DateTime::TimeZone::America::Miquelon 2.65
-      DateTime::TimeZone::America::Moncton 2.65
-      DateTime::TimeZone::America::Monterrey 2.65
-      DateTime::TimeZone::America::Montevideo 2.65
-      DateTime::TimeZone::America::New_York 2.65
-      DateTime::TimeZone::America::Nome 2.65
-      DateTime::TimeZone::America::Noronha 2.65
-      DateTime::TimeZone::America::North_Dakota::Beulah 2.65
-      DateTime::TimeZone::America::North_Dakota::Center 2.65
-      DateTime::TimeZone::America::North_Dakota::New_Salem 2.65
-      DateTime::TimeZone::America::Nuuk 2.65
-      DateTime::TimeZone::America::Ojinaga 2.65
-      DateTime::TimeZone::America::Panama 2.65
-      DateTime::TimeZone::America::Paramaribo 2.65
-      DateTime::TimeZone::America::Phoenix 2.65
-      DateTime::TimeZone::America::Port_au_Prince 2.65
-      DateTime::TimeZone::America::Porto_Velho 2.65
-      DateTime::TimeZone::America::Puerto_Rico 2.65
-      DateTime::TimeZone::America::Punta_Arenas 2.65
-      DateTime::TimeZone::America::Rankin_Inlet 2.65
-      DateTime::TimeZone::America::Recife 2.65
-      DateTime::TimeZone::America::Regina 2.65
-      DateTime::TimeZone::America::Resolute 2.65
-      DateTime::TimeZone::America::Rio_Branco 2.65
-      DateTime::TimeZone::America::Santarem 2.65
-      DateTime::TimeZone::America::Santiago 2.65
-      DateTime::TimeZone::America::Santo_Domingo 2.65
-      DateTime::TimeZone::America::Sao_Paulo 2.65
-      DateTime::TimeZone::America::Scoresbysund 2.65
-      DateTime::TimeZone::America::Sitka 2.65
-      DateTime::TimeZone::America::St_Johns 2.65
-      DateTime::TimeZone::America::Swift_Current 2.65
-      DateTime::TimeZone::America::Tegucigalpa 2.65
-      DateTime::TimeZone::America::Thule 2.65
-      DateTime::TimeZone::America::Tijuana 2.65
-      DateTime::TimeZone::America::Toronto 2.65
-      DateTime::TimeZone::America::Vancouver 2.65
-      DateTime::TimeZone::America::Whitehorse 2.65
-      DateTime::TimeZone::America::Winnipeg 2.65
-      DateTime::TimeZone::America::Yakutat 2.65
-      DateTime::TimeZone::Antarctica::Casey 2.65
-      DateTime::TimeZone::Antarctica::Davis 2.65
-      DateTime::TimeZone::Antarctica::Macquarie 2.65
-      DateTime::TimeZone::Antarctica::Mawson 2.65
-      DateTime::TimeZone::Antarctica::Palmer 2.65
-      DateTime::TimeZone::Antarctica::Rothera 2.65
-      DateTime::TimeZone::Antarctica::Troll 2.65
-      DateTime::TimeZone::Antarctica::Vostok 2.65
-      DateTime::TimeZone::Asia::Almaty 2.65
-      DateTime::TimeZone::Asia::Amman 2.65
-      DateTime::TimeZone::Asia::Anadyr 2.65
-      DateTime::TimeZone::Asia::Aqtau 2.65
-      DateTime::TimeZone::Asia::Aqtobe 2.65
-      DateTime::TimeZone::Asia::Ashgabat 2.65
-      DateTime::TimeZone::Asia::Atyrau 2.65
-      DateTime::TimeZone::Asia::Baghdad 2.65
-      DateTime::TimeZone::Asia::Baku 2.65
-      DateTime::TimeZone::Asia::Bangkok 2.65
-      DateTime::TimeZone::Asia::Barnaul 2.65
-      DateTime::TimeZone::Asia::Beirut 2.65
-      DateTime::TimeZone::Asia::Bishkek 2.65
-      DateTime::TimeZone::Asia::Chita 2.65
-      DateTime::TimeZone::Asia::Colombo 2.65
-      DateTime::TimeZone::Asia::Damascus 2.65
-      DateTime::TimeZone::Asia::Dhaka 2.65
-      DateTime::TimeZone::Asia::Dili 2.65
-      DateTime::TimeZone::Asia::Dubai 2.65
-      DateTime::TimeZone::Asia::Dushanbe 2.65
-      DateTime::TimeZone::Asia::Famagusta 2.65
-      DateTime::TimeZone::Asia::Gaza 2.65
-      DateTime::TimeZone::Asia::Hebron 2.65
-      DateTime::TimeZone::Asia::Ho_Chi_Minh 2.65
-      DateTime::TimeZone::Asia::Hong_Kong 2.65
-      DateTime::TimeZone::Asia::Hovd 2.65
-      DateTime::TimeZone::Asia::Irkutsk 2.65
-      DateTime::TimeZone::Asia::Jakarta 2.65
-      DateTime::TimeZone::Asia::Jayapura 2.65
-      DateTime::TimeZone::Asia::Jerusalem 2.65
-      DateTime::TimeZone::Asia::Kabul 2.65
-      DateTime::TimeZone::Asia::Kamchatka 2.65
-      DateTime::TimeZone::Asia::Karachi 2.65
-      DateTime::TimeZone::Asia::Kathmandu 2.65
-      DateTime::TimeZone::Asia::Khandyga 2.65
-      DateTime::TimeZone::Asia::Kolkata 2.65
-      DateTime::TimeZone::Asia::Krasnoyarsk 2.65
-      DateTime::TimeZone::Asia::Kuching 2.65
-      DateTime::TimeZone::Asia::Macau 2.65
-      DateTime::TimeZone::Asia::Magadan 2.65
-      DateTime::TimeZone::Asia::Makassar 2.65
-      DateTime::TimeZone::Asia::Manila 2.65
-      DateTime::TimeZone::Asia::Nicosia 2.65
-      DateTime::TimeZone::Asia::Novokuznetsk 2.65
-      DateTime::TimeZone::Asia::Novosibirsk 2.65
-      DateTime::TimeZone::Asia::Omsk 2.65
-      DateTime::TimeZone::Asia::Oral 2.65
-      DateTime::TimeZone::Asia::Pontianak 2.65
-      DateTime::TimeZone::Asia::Pyongyang 2.65
-      DateTime::TimeZone::Asia::Qatar 2.65
-      DateTime::TimeZone::Asia::Qostanay 2.65
-      DateTime::TimeZone::Asia::Qyzylorda 2.65
-      DateTime::TimeZone::Asia::Riyadh 2.65
-      DateTime::TimeZone::Asia::Sakhalin 2.65
-      DateTime::TimeZone::Asia::Samarkand 2.65
-      DateTime::TimeZone::Asia::Seoul 2.65
-      DateTime::TimeZone::Asia::Shanghai 2.65
-      DateTime::TimeZone::Asia::Singapore 2.65
-      DateTime::TimeZone::Asia::Srednekolymsk 2.65
-      DateTime::TimeZone::Asia::Taipei 2.65
-      DateTime::TimeZone::Asia::Tashkent 2.65
-      DateTime::TimeZone::Asia::Tbilisi 2.65
-      DateTime::TimeZone::Asia::Tehran 2.65
-      DateTime::TimeZone::Asia::Thimphu 2.65
-      DateTime::TimeZone::Asia::Tokyo 2.65
-      DateTime::TimeZone::Asia::Tomsk 2.65
-      DateTime::TimeZone::Asia::Ulaanbaatar 2.65
-      DateTime::TimeZone::Asia::Urumqi 2.65
-      DateTime::TimeZone::Asia::Ust_Nera 2.65
-      DateTime::TimeZone::Asia::Vladivostok 2.65
-      DateTime::TimeZone::Asia::Yakutsk 2.65
-      DateTime::TimeZone::Asia::Yangon 2.65
-      DateTime::TimeZone::Asia::Yekaterinburg 2.65
-      DateTime::TimeZone::Asia::Yerevan 2.65
-      DateTime::TimeZone::Atlantic::Azores 2.65
-      DateTime::TimeZone::Atlantic::Bermuda 2.65
-      DateTime::TimeZone::Atlantic::Canary 2.65
-      DateTime::TimeZone::Atlantic::Cape_Verde 2.65
-      DateTime::TimeZone::Atlantic::Faroe 2.65
-      DateTime::TimeZone::Atlantic::Madeira 2.65
-      DateTime::TimeZone::Atlantic::South_Georgia 2.65
-      DateTime::TimeZone::Atlantic::Stanley 2.65
-      DateTime::TimeZone::Australia::Adelaide 2.65
-      DateTime::TimeZone::Australia::Brisbane 2.65
-      DateTime::TimeZone::Australia::Broken_Hill 2.65
-      DateTime::TimeZone::Australia::Darwin 2.65
-      DateTime::TimeZone::Australia::Eucla 2.65
-      DateTime::TimeZone::Australia::Hobart 2.65
-      DateTime::TimeZone::Australia::Lindeman 2.65
-      DateTime::TimeZone::Australia::Lord_Howe 2.65
-      DateTime::TimeZone::Australia::Melbourne 2.65
-      DateTime::TimeZone::Australia::Perth 2.65
-      DateTime::TimeZone::Australia::Sydney 2.65
-      DateTime::TimeZone::Catalog 2.65
-      DateTime::TimeZone::Europe::Andorra 2.65
-      DateTime::TimeZone::Europe::Astrakhan 2.65
-      DateTime::TimeZone::Europe::Athens 2.65
-      DateTime::TimeZone::Europe::Belgrade 2.65
-      DateTime::TimeZone::Europe::Berlin 2.65
-      DateTime::TimeZone::Europe::Brussels 2.65
-      DateTime::TimeZone::Europe::Bucharest 2.65
-      DateTime::TimeZone::Europe::Budapest 2.65
-      DateTime::TimeZone::Europe::Chisinau 2.65
-      DateTime::TimeZone::Europe::Dublin 2.65
-      DateTime::TimeZone::Europe::Gibraltar 2.65
-      DateTime::TimeZone::Europe::Helsinki 2.65
-      DateTime::TimeZone::Europe::Istanbul 2.65
-      DateTime::TimeZone::Europe::Kaliningrad 2.65
-      DateTime::TimeZone::Europe::Kirov 2.65
-      DateTime::TimeZone::Europe::Kyiv 2.65
-      DateTime::TimeZone::Europe::Lisbon 2.65
-      DateTime::TimeZone::Europe::London 2.65
-      DateTime::TimeZone::Europe::Madrid 2.65
-      DateTime::TimeZone::Europe::Malta 2.65
-      DateTime::TimeZone::Europe::Minsk 2.65
-      DateTime::TimeZone::Europe::Moscow 2.65
-      DateTime::TimeZone::Europe::Paris 2.65
-      DateTime::TimeZone::Europe::Prague 2.65
-      DateTime::TimeZone::Europe::Riga 2.65
-      DateTime::TimeZone::Europe::Rome 2.65
-      DateTime::TimeZone::Europe::Samara 2.65
-      DateTime::TimeZone::Europe::Saratov 2.65
-      DateTime::TimeZone::Europe::Simferopol 2.65
-      DateTime::TimeZone::Europe::Sofia 2.65
-      DateTime::TimeZone::Europe::Tallinn 2.65
-      DateTime::TimeZone::Europe::Tirane 2.65
-      DateTime::TimeZone::Europe::Ulyanovsk 2.65
-      DateTime::TimeZone::Europe::Vienna 2.65
-      DateTime::TimeZone::Europe::Vilnius 2.65
-      DateTime::TimeZone::Europe::Volgograd 2.65
-      DateTime::TimeZone::Europe::Warsaw 2.65
-      DateTime::TimeZone::Europe::Zurich 2.65
-      DateTime::TimeZone::Floating 2.65
-      DateTime::TimeZone::Indian::Chagos 2.65
-      DateTime::TimeZone::Indian::Maldives 2.65
-      DateTime::TimeZone::Indian::Mauritius 2.65
-      DateTime::TimeZone::Local 2.65
-      DateTime::TimeZone::Local::Android 2.65
-      DateTime::TimeZone::Local::Unix 2.65
-      DateTime::TimeZone::Local::VMS 2.65
-      DateTime::TimeZone::OffsetOnly 2.65
-      DateTime::TimeZone::OlsonDB 2.65
-      DateTime::TimeZone::OlsonDB::Change 2.65
-      DateTime::TimeZone::OlsonDB::Observance 2.65
-      DateTime::TimeZone::OlsonDB::Rule 2.65
-      DateTime::TimeZone::OlsonDB::Zone 2.65
-      DateTime::TimeZone::Pacific::Apia 2.65
-      DateTime::TimeZone::Pacific::Auckland 2.65
-      DateTime::TimeZone::Pacific::Bougainville 2.65
-      DateTime::TimeZone::Pacific::Chatham 2.65
-      DateTime::TimeZone::Pacific::Easter 2.65
-      DateTime::TimeZone::Pacific::Efate 2.65
-      DateTime::TimeZone::Pacific::Fakaofo 2.65
-      DateTime::TimeZone::Pacific::Fiji 2.65
-      DateTime::TimeZone::Pacific::Galapagos 2.65
-      DateTime::TimeZone::Pacific::Gambier 2.65
-      DateTime::TimeZone::Pacific::Guadalcanal 2.65
-      DateTime::TimeZone::Pacific::Guam 2.65
-      DateTime::TimeZone::Pacific::Honolulu 2.65
-      DateTime::TimeZone::Pacific::Kanton 2.65
-      DateTime::TimeZone::Pacific::Kiritimati 2.65
-      DateTime::TimeZone::Pacific::Kosrae 2.65
-      DateTime::TimeZone::Pacific::Kwajalein 2.65
-      DateTime::TimeZone::Pacific::Marquesas 2.65
-      DateTime::TimeZone::Pacific::Nauru 2.65
-      DateTime::TimeZone::Pacific::Niue 2.65
-      DateTime::TimeZone::Pacific::Norfolk 2.65
-      DateTime::TimeZone::Pacific::Noumea 2.65
-      DateTime::TimeZone::Pacific::Pago_Pago 2.65
-      DateTime::TimeZone::Pacific::Palau 2.65
-      DateTime::TimeZone::Pacific::Pitcairn 2.65
-      DateTime::TimeZone::Pacific::Port_Moresby 2.65
-      DateTime::TimeZone::Pacific::Rarotonga 2.65
-      DateTime::TimeZone::Pacific::Tahiti 2.65
-      DateTime::TimeZone::Pacific::Tarawa 2.65
-      DateTime::TimeZone::Pacific::Tongatapu 2.65
-      DateTime::TimeZone::UTC 2.65
+      DateTime::TimeZone 2.69
+      DateTime::TimeZone::Africa::Abidjan 2.69
+      DateTime::TimeZone::Africa::Algiers 2.69
+      DateTime::TimeZone::Africa::Bissau 2.69
+      DateTime::TimeZone::Africa::Cairo 2.69
+      DateTime::TimeZone::Africa::Casablanca 2.69
+      DateTime::TimeZone::Africa::Ceuta 2.69
+      DateTime::TimeZone::Africa::El_Aaiun 2.69
+      DateTime::TimeZone::Africa::Johannesburg 2.69
+      DateTime::TimeZone::Africa::Juba 2.69
+      DateTime::TimeZone::Africa::Khartoum 2.69
+      DateTime::TimeZone::Africa::Lagos 2.69
+      DateTime::TimeZone::Africa::Maputo 2.69
+      DateTime::TimeZone::Africa::Monrovia 2.69
+      DateTime::TimeZone::Africa::Nairobi 2.69
+      DateTime::TimeZone::Africa::Ndjamena 2.69
+      DateTime::TimeZone::Africa::Sao_Tome 2.69
+      DateTime::TimeZone::Africa::Tripoli 2.69
+      DateTime::TimeZone::Africa::Tunis 2.69
+      DateTime::TimeZone::Africa::Windhoek 2.69
+      DateTime::TimeZone::America::Adak 2.69
+      DateTime::TimeZone::America::Anchorage 2.69
+      DateTime::TimeZone::America::Araguaina 2.69
+      DateTime::TimeZone::America::Argentina::Buenos_Aires 2.69
+      DateTime::TimeZone::America::Argentina::Catamarca 2.69
+      DateTime::TimeZone::America::Argentina::Cordoba 2.69
+      DateTime::TimeZone::America::Argentina::Jujuy 2.69
+      DateTime::TimeZone::America::Argentina::La_Rioja 2.69
+      DateTime::TimeZone::America::Argentina::Mendoza 2.69
+      DateTime::TimeZone::America::Argentina::Rio_Gallegos 2.69
+      DateTime::TimeZone::America::Argentina::Salta 2.69
+      DateTime::TimeZone::America::Argentina::San_Juan 2.69
+      DateTime::TimeZone::America::Argentina::San_Luis 2.69
+      DateTime::TimeZone::America::Argentina::Tucuman 2.69
+      DateTime::TimeZone::America::Argentina::Ushuaia 2.69
+      DateTime::TimeZone::America::Asuncion 2.69
+      DateTime::TimeZone::America::Bahia 2.69
+      DateTime::TimeZone::America::Bahia_Banderas 2.69
+      DateTime::TimeZone::America::Barbados 2.69
+      DateTime::TimeZone::America::Belem 2.69
+      DateTime::TimeZone::America::Belize 2.69
+      DateTime::TimeZone::America::Boa_Vista 2.69
+      DateTime::TimeZone::America::Bogota 2.69
+      DateTime::TimeZone::America::Boise 2.69
+      DateTime::TimeZone::America::Cambridge_Bay 2.69
+      DateTime::TimeZone::America::Campo_Grande 2.69
+      DateTime::TimeZone::America::Cancun 2.69
+      DateTime::TimeZone::America::Caracas 2.69
+      DateTime::TimeZone::America::Cayenne 2.69
+      DateTime::TimeZone::America::Chicago 2.69
+      DateTime::TimeZone::America::Chihuahua 2.69
+      DateTime::TimeZone::America::Ciudad_Juarez 2.69
+      DateTime::TimeZone::America::Costa_Rica 2.69
+      DateTime::TimeZone::America::Coyhaique 2.69
+      DateTime::TimeZone::America::Cuiaba 2.69
+      DateTime::TimeZone::America::Danmarkshavn 2.69
+      DateTime::TimeZone::America::Dawson 2.69
+      DateTime::TimeZone::America::Dawson_Creek 2.69
+      DateTime::TimeZone::America::Denver 2.69
+      DateTime::TimeZone::America::Detroit 2.69
+      DateTime::TimeZone::America::Edmonton 2.69
+      DateTime::TimeZone::America::Eirunepe 2.69
+      DateTime::TimeZone::America::El_Salvador 2.69
+      DateTime::TimeZone::America::Fort_Nelson 2.69
+      DateTime::TimeZone::America::Fortaleza 2.69
+      DateTime::TimeZone::America::Glace_Bay 2.69
+      DateTime::TimeZone::America::Goose_Bay 2.69
+      DateTime::TimeZone::America::Grand_Turk 2.69
+      DateTime::TimeZone::America::Guatemala 2.69
+      DateTime::TimeZone::America::Guayaquil 2.69
+      DateTime::TimeZone::America::Guyana 2.69
+      DateTime::TimeZone::America::Halifax 2.69
+      DateTime::TimeZone::America::Havana 2.69
+      DateTime::TimeZone::America::Hermosillo 2.69
+      DateTime::TimeZone::America::Indiana::Indianapolis 2.69
+      DateTime::TimeZone::America::Indiana::Knox 2.69
+      DateTime::TimeZone::America::Indiana::Marengo 2.69
+      DateTime::TimeZone::America::Indiana::Petersburg 2.69
+      DateTime::TimeZone::America::Indiana::Tell_City 2.69
+      DateTime::TimeZone::America::Indiana::Vevay 2.69
+      DateTime::TimeZone::America::Indiana::Vincennes 2.69
+      DateTime::TimeZone::America::Indiana::Winamac 2.69
+      DateTime::TimeZone::America::Inuvik 2.69
+      DateTime::TimeZone::America::Iqaluit 2.69
+      DateTime::TimeZone::America::Jamaica 2.69
+      DateTime::TimeZone::America::Juneau 2.69
+      DateTime::TimeZone::America::Kentucky::Louisville 2.69
+      DateTime::TimeZone::America::Kentucky::Monticello 2.69
+      DateTime::TimeZone::America::La_Paz 2.69
+      DateTime::TimeZone::America::Lima 2.69
+      DateTime::TimeZone::America::Los_Angeles 2.69
+      DateTime::TimeZone::America::Maceio 2.69
+      DateTime::TimeZone::America::Managua 2.69
+      DateTime::TimeZone::America::Manaus 2.69
+      DateTime::TimeZone::America::Martinique 2.69
+      DateTime::TimeZone::America::Matamoros 2.69
+      DateTime::TimeZone::America::Mazatlan 2.69
+      DateTime::TimeZone::America::Menominee 2.69
+      DateTime::TimeZone::America::Merida 2.69
+      DateTime::TimeZone::America::Metlakatla 2.69
+      DateTime::TimeZone::America::Mexico_City 2.69
+      DateTime::TimeZone::America::Miquelon 2.69
+      DateTime::TimeZone::America::Moncton 2.69
+      DateTime::TimeZone::America::Monterrey 2.69
+      DateTime::TimeZone::America::Montevideo 2.69
+      DateTime::TimeZone::America::New_York 2.69
+      DateTime::TimeZone::America::Nome 2.69
+      DateTime::TimeZone::America::Noronha 2.69
+      DateTime::TimeZone::America::North_Dakota::Beulah 2.69
+      DateTime::TimeZone::America::North_Dakota::Center 2.69
+      DateTime::TimeZone::America::North_Dakota::New_Salem 2.69
+      DateTime::TimeZone::America::Nuuk 2.69
+      DateTime::TimeZone::America::Ojinaga 2.69
+      DateTime::TimeZone::America::Panama 2.69
+      DateTime::TimeZone::America::Paramaribo 2.69
+      DateTime::TimeZone::America::Phoenix 2.69
+      DateTime::TimeZone::America::Port_au_Prince 2.69
+      DateTime::TimeZone::America::Porto_Velho 2.69
+      DateTime::TimeZone::America::Puerto_Rico 2.69
+      DateTime::TimeZone::America::Punta_Arenas 2.69
+      DateTime::TimeZone::America::Rankin_Inlet 2.69
+      DateTime::TimeZone::America::Recife 2.69
+      DateTime::TimeZone::America::Regina 2.69
+      DateTime::TimeZone::America::Resolute 2.69
+      DateTime::TimeZone::America::Rio_Branco 2.69
+      DateTime::TimeZone::America::Santarem 2.69
+      DateTime::TimeZone::America::Santiago 2.69
+      DateTime::TimeZone::America::Santo_Domingo 2.69
+      DateTime::TimeZone::America::Sao_Paulo 2.69
+      DateTime::TimeZone::America::Scoresbysund 2.69
+      DateTime::TimeZone::America::Sitka 2.69
+      DateTime::TimeZone::America::St_Johns 2.69
+      DateTime::TimeZone::America::Swift_Current 2.69
+      DateTime::TimeZone::America::Tegucigalpa 2.69
+      DateTime::TimeZone::America::Thule 2.69
+      DateTime::TimeZone::America::Tijuana 2.69
+      DateTime::TimeZone::America::Toronto 2.69
+      DateTime::TimeZone::America::Vancouver 2.69
+      DateTime::TimeZone::America::Whitehorse 2.69
+      DateTime::TimeZone::America::Winnipeg 2.69
+      DateTime::TimeZone::America::Yakutat 2.69
+      DateTime::TimeZone::Antarctica::Casey 2.69
+      DateTime::TimeZone::Antarctica::Davis 2.69
+      DateTime::TimeZone::Antarctica::Macquarie 2.69
+      DateTime::TimeZone::Antarctica::Mawson 2.69
+      DateTime::TimeZone::Antarctica::Palmer 2.69
+      DateTime::TimeZone::Antarctica::Rothera 2.69
+      DateTime::TimeZone::Antarctica::Troll 2.69
+      DateTime::TimeZone::Antarctica::Vostok 2.69
+      DateTime::TimeZone::Asia::Almaty 2.69
+      DateTime::TimeZone::Asia::Amman 2.69
+      DateTime::TimeZone::Asia::Anadyr 2.69
+      DateTime::TimeZone::Asia::Aqtau 2.69
+      DateTime::TimeZone::Asia::Aqtobe 2.69
+      DateTime::TimeZone::Asia::Ashgabat 2.69
+      DateTime::TimeZone::Asia::Atyrau 2.69
+      DateTime::TimeZone::Asia::Baghdad 2.69
+      DateTime::TimeZone::Asia::Baku 2.69
+      DateTime::TimeZone::Asia::Bangkok 2.69
+      DateTime::TimeZone::Asia::Barnaul 2.69
+      DateTime::TimeZone::Asia::Beirut 2.69
+      DateTime::TimeZone::Asia::Bishkek 2.69
+      DateTime::TimeZone::Asia::Chita 2.69
+      DateTime::TimeZone::Asia::Colombo 2.69
+      DateTime::TimeZone::Asia::Damascus 2.69
+      DateTime::TimeZone::Asia::Dhaka 2.69
+      DateTime::TimeZone::Asia::Dili 2.69
+      DateTime::TimeZone::Asia::Dubai 2.69
+      DateTime::TimeZone::Asia::Dushanbe 2.69
+      DateTime::TimeZone::Asia::Famagusta 2.69
+      DateTime::TimeZone::Asia::Gaza 2.69
+      DateTime::TimeZone::Asia::Hebron 2.69
+      DateTime::TimeZone::Asia::Ho_Chi_Minh 2.69
+      DateTime::TimeZone::Asia::Hong_Kong 2.69
+      DateTime::TimeZone::Asia::Hovd 2.69
+      DateTime::TimeZone::Asia::Irkutsk 2.69
+      DateTime::TimeZone::Asia::Jakarta 2.69
+      DateTime::TimeZone::Asia::Jayapura 2.69
+      DateTime::TimeZone::Asia::Jerusalem 2.69
+      DateTime::TimeZone::Asia::Kabul 2.69
+      DateTime::TimeZone::Asia::Kamchatka 2.69
+      DateTime::TimeZone::Asia::Karachi 2.69
+      DateTime::TimeZone::Asia::Kathmandu 2.69
+      DateTime::TimeZone::Asia::Khandyga 2.69
+      DateTime::TimeZone::Asia::Kolkata 2.69
+      DateTime::TimeZone::Asia::Krasnoyarsk 2.69
+      DateTime::TimeZone::Asia::Kuching 2.69
+      DateTime::TimeZone::Asia::Macau 2.69
+      DateTime::TimeZone::Asia::Magadan 2.69
+      DateTime::TimeZone::Asia::Makassar 2.69
+      DateTime::TimeZone::Asia::Manila 2.69
+      DateTime::TimeZone::Asia::Nicosia 2.69
+      DateTime::TimeZone::Asia::Novokuznetsk 2.69
+      DateTime::TimeZone::Asia::Novosibirsk 2.69
+      DateTime::TimeZone::Asia::Omsk 2.69
+      DateTime::TimeZone::Asia::Oral 2.69
+      DateTime::TimeZone::Asia::Pontianak 2.69
+      DateTime::TimeZone::Asia::Pyongyang 2.69
+      DateTime::TimeZone::Asia::Qatar 2.69
+      DateTime::TimeZone::Asia::Qostanay 2.69
+      DateTime::TimeZone::Asia::Qyzylorda 2.69
+      DateTime::TimeZone::Asia::Riyadh 2.69
+      DateTime::TimeZone::Asia::Sakhalin 2.69
+      DateTime::TimeZone::Asia::Samarkand 2.69
+      DateTime::TimeZone::Asia::Seoul 2.69
+      DateTime::TimeZone::Asia::Shanghai 2.69
+      DateTime::TimeZone::Asia::Singapore 2.69
+      DateTime::TimeZone::Asia::Srednekolymsk 2.69
+      DateTime::TimeZone::Asia::Taipei 2.69
+      DateTime::TimeZone::Asia::Tashkent 2.69
+      DateTime::TimeZone::Asia::Tbilisi 2.69
+      DateTime::TimeZone::Asia::Tehran 2.69
+      DateTime::TimeZone::Asia::Thimphu 2.69
+      DateTime::TimeZone::Asia::Tokyo 2.69
+      DateTime::TimeZone::Asia::Tomsk 2.69
+      DateTime::TimeZone::Asia::Ulaanbaatar 2.69
+      DateTime::TimeZone::Asia::Urumqi 2.69
+      DateTime::TimeZone::Asia::Ust_Nera 2.69
+      DateTime::TimeZone::Asia::Vladivostok 2.69
+      DateTime::TimeZone::Asia::Yakutsk 2.69
+      DateTime::TimeZone::Asia::Yangon 2.69
+      DateTime::TimeZone::Asia::Yekaterinburg 2.69
+      DateTime::TimeZone::Asia::Yerevan 2.69
+      DateTime::TimeZone::Atlantic::Azores 2.69
+      DateTime::TimeZone::Atlantic::Bermuda 2.69
+      DateTime::TimeZone::Atlantic::Canary 2.69
+      DateTime::TimeZone::Atlantic::Cape_Verde 2.69
+      DateTime::TimeZone::Atlantic::Faroe 2.69
+      DateTime::TimeZone::Atlantic::Madeira 2.69
+      DateTime::TimeZone::Atlantic::South_Georgia 2.69
+      DateTime::TimeZone::Atlantic::Stanley 2.69
+      DateTime::TimeZone::Australia::Adelaide 2.69
+      DateTime::TimeZone::Australia::Brisbane 2.69
+      DateTime::TimeZone::Australia::Broken_Hill 2.69
+      DateTime::TimeZone::Australia::Darwin 2.69
+      DateTime::TimeZone::Australia::Eucla 2.69
+      DateTime::TimeZone::Australia::Hobart 2.69
+      DateTime::TimeZone::Australia::Lindeman 2.69
+      DateTime::TimeZone::Australia::Lord_Howe 2.69
+      DateTime::TimeZone::Australia::Melbourne 2.69
+      DateTime::TimeZone::Australia::Perth 2.69
+      DateTime::TimeZone::Australia::Sydney 2.69
+      DateTime::TimeZone::Catalog 2.69
+      DateTime::TimeZone::Europe::Andorra 2.69
+      DateTime::TimeZone::Europe::Astrakhan 2.69
+      DateTime::TimeZone::Europe::Athens 2.69
+      DateTime::TimeZone::Europe::Belgrade 2.69
+      DateTime::TimeZone::Europe::Berlin 2.69
+      DateTime::TimeZone::Europe::Brussels 2.69
+      DateTime::TimeZone::Europe::Bucharest 2.69
+      DateTime::TimeZone::Europe::Budapest 2.69
+      DateTime::TimeZone::Europe::Chisinau 2.69
+      DateTime::TimeZone::Europe::Dublin 2.69
+      DateTime::TimeZone::Europe::Gibraltar 2.69
+      DateTime::TimeZone::Europe::Helsinki 2.69
+      DateTime::TimeZone::Europe::Istanbul 2.69
+      DateTime::TimeZone::Europe::Kaliningrad 2.69
+      DateTime::TimeZone::Europe::Kirov 2.69
+      DateTime::TimeZone::Europe::Kyiv 2.69
+      DateTime::TimeZone::Europe::Lisbon 2.69
+      DateTime::TimeZone::Europe::London 2.69
+      DateTime::TimeZone::Europe::Madrid 2.69
+      DateTime::TimeZone::Europe::Malta 2.69
+      DateTime::TimeZone::Europe::Minsk 2.69
+      DateTime::TimeZone::Europe::Moscow 2.69
+      DateTime::TimeZone::Europe::Paris 2.69
+      DateTime::TimeZone::Europe::Prague 2.69
+      DateTime::TimeZone::Europe::Riga 2.69
+      DateTime::TimeZone::Europe::Rome 2.69
+      DateTime::TimeZone::Europe::Samara 2.69
+      DateTime::TimeZone::Europe::Saratov 2.69
+      DateTime::TimeZone::Europe::Simferopol 2.69
+      DateTime::TimeZone::Europe::Sofia 2.69
+      DateTime::TimeZone::Europe::Tallinn 2.69
+      DateTime::TimeZone::Europe::Tirane 2.69
+      DateTime::TimeZone::Europe::Ulyanovsk 2.69
+      DateTime::TimeZone::Europe::Vienna 2.69
+      DateTime::TimeZone::Europe::Vilnius 2.69
+      DateTime::TimeZone::Europe::Volgograd 2.69
+      DateTime::TimeZone::Europe::Warsaw 2.69
+      DateTime::TimeZone::Europe::Zurich 2.69
+      DateTime::TimeZone::Floating 2.69
+      DateTime::TimeZone::Indian::Chagos 2.69
+      DateTime::TimeZone::Indian::Maldives 2.69
+      DateTime::TimeZone::Indian::Mauritius 2.69
+      DateTime::TimeZone::Local 2.69
+      DateTime::TimeZone::Local::Android 2.69
+      DateTime::TimeZone::Local::Unix 2.69
+      DateTime::TimeZone::Local::VMS 2.69
+      DateTime::TimeZone::OffsetOnly 2.69
+      DateTime::TimeZone::OlsonDB 2.69
+      DateTime::TimeZone::OlsonDB::Change 2.69
+      DateTime::TimeZone::OlsonDB::Observance 2.69
+      DateTime::TimeZone::OlsonDB::Rule 2.69
+      DateTime::TimeZone::OlsonDB::Zone 2.69
+      DateTime::TimeZone::Pacific::Apia 2.69
+      DateTime::TimeZone::Pacific::Auckland 2.69
+      DateTime::TimeZone::Pacific::Bougainville 2.69
+      DateTime::TimeZone::Pacific::Chatham 2.69
+      DateTime::TimeZone::Pacific::Easter 2.69
+      DateTime::TimeZone::Pacific::Efate 2.69
+      DateTime::TimeZone::Pacific::Fakaofo 2.69
+      DateTime::TimeZone::Pacific::Fiji 2.69
+      DateTime::TimeZone::Pacific::Galapagos 2.69
+      DateTime::TimeZone::Pacific::Gambier 2.69
+      DateTime::TimeZone::Pacific::Guadalcanal 2.69
+      DateTime::TimeZone::Pacific::Guam 2.69
+      DateTime::TimeZone::Pacific::Honolulu 2.69
+      DateTime::TimeZone::Pacific::Kanton 2.69
+      DateTime::TimeZone::Pacific::Kiritimati 2.69
+      DateTime::TimeZone::Pacific::Kosrae 2.69
+      DateTime::TimeZone::Pacific::Kwajalein 2.69
+      DateTime::TimeZone::Pacific::Marquesas 2.69
+      DateTime::TimeZone::Pacific::Nauru 2.69
+      DateTime::TimeZone::Pacific::Niue 2.69
+      DateTime::TimeZone::Pacific::Norfolk 2.69
+      DateTime::TimeZone::Pacific::Noumea 2.69
+      DateTime::TimeZone::Pacific::Pago_Pago 2.69
+      DateTime::TimeZone::Pacific::Palau 2.69
+      DateTime::TimeZone::Pacific::Pitcairn 2.69
+      DateTime::TimeZone::Pacific::Port_Moresby 2.69
+      DateTime::TimeZone::Pacific::Rarotonga 2.69
+      DateTime::TimeZone::Pacific::Tahiti 2.69
+      DateTime::TimeZone::Pacific::Tarawa 2.69
+      DateTime::TimeZone::Pacific::Tongatapu 2.69
+      DateTime::TimeZone::UTC 2.69
     requirements:
       Class::Singleton 1.03
       Cwd 3
@@ -2270,22 +2290,22 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Sub::Exporter::Progressive 0.001011
       perl 5.006
-  Devel-NYTProf-6.14
-    pathname: J/JK/JKEENAN/Devel-NYTProf-6.14.tar.gz
+  Devel-NYTProf-6.15
+    pathname: J/JK/JKEENAN/Devel-NYTProf-6.15.tar.gz
     provides:
-      Devel::NYTProf 6.14
-      Devel::NYTProf::Apache 6.14
+      Devel::NYTProf 6.15
+      Devel::NYTProf::Apache 6.15
       Devel::NYTProf::Constants undef
-      Devel::NYTProf::Core 6.14
-      Devel::NYTProf::Data 6.14
+      Devel::NYTProf::Core 6.15
+      Devel::NYTProf::Data 6.15
       Devel::NYTProf::FileHandle undef
       Devel::NYTProf::FileInfo undef
-      Devel::NYTProf::ReadStream 6.14
-      Devel::NYTProf::Reader 6.14
+      Devel::NYTProf::ReadStream 6.15
+      Devel::NYTProf::Reader 6.15
       Devel::NYTProf::Run undef
       Devel::NYTProf::SubCallInfo undef
       Devel::NYTProf::SubInfo undef
-      Devel::NYTProf::Util 6.14
+      Devel::NYTProf::Util 6.15
     requirements:
       ExtUtils::MakeMaker 0
       File::Which 1.09
@@ -2364,55 +2384,32 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.003
-  Dist-Build-0.022
-    pathname: L/LE/LEONT/Dist-Build-0.022.tar.gz
+  Dist-Build-0.028
+    pathname: L/LE/LEONT/Dist-Build-0.028.tar.gz
     provides:
-      Dist::Build 0.022
-      Dist::Build::Core 0.022
-      Dist::Build::Serializer 0.022
-      Dist::Build::ShareDir 0.022
-      Dist::Build::Util 0.022
-      Dist::Build::XS 0.022
-      Dist::Build::XS::Alien 0.022
-      Dist::Build::XS::Conf 0.022
-      Dist::Build::XS::Export 0.022
-      Dist::Build::XS::Import 0.022
-      Dist::Build::XS::WriteConstants 0.022
+      Dist::Build 0.028
+      Dist::Build::Core 0.028
+      Dist::Build::Serializer 0.028
+      Dist::Build::ShareDir 0.028
+      Dist::Build::Util 0.028
+      Dist::Build::XS 0.028
+      Dist::Build::XS::Alien 0.028
+      Dist::Build::XS::Conf 0.028
+      Dist::Build::XS::Export 0.028
+      Dist::Build::XS::Import 0.028
+      Dist::Build::XS::WriteConstants 0.028
     requirements:
-      CPAN::Meta 0
-      CPAN::Meta::Merge 0
-      Carp 0
-      Exporter 5.57
-      ExtUtils::Builder::Action::Function 0
-      ExtUtils::Builder::Compiler 0.028
-      ExtUtils::Builder::Node 0
-      ExtUtils::Builder::ParseXS 0
-      ExtUtils::Builder::Planner 0.016
-      ExtUtils::Builder::Planner::Extension 0
-      ExtUtils::Builder::Serializer 0
-      ExtUtils::Builder::Util 0.018
+      CPAN::Meta 2.142060
+      ExtUtils::Builder 0.020
+      ExtUtils::Builder::Compiler 0.036
       ExtUtils::Config 0
       ExtUtils::Helpers 0.028
-      ExtUtils::Install 0
       ExtUtils::InstallPaths 0
-      ExtUtils::Manifest 0
-      File::Basename 0
-      File::Copy 0
-      File::Find 0
-      File::Path 0
-      File::Spec::Functions 0
       Getopt::Long 2.36
       List::Util 1.33
-      Parse::CPAN::Meta 0
-      Perl::OSType 0
-      Pod::Man 0
-      TAP::Harness::Env 0
-      Text::ParseWords 0
+      TAP::Harness 3.29
       parent 0
       perl 5.010
-      strict 0
-      version 0
-      warnings 0
   Dist-CheckConflicts-0.11
     pathname: D/DO/DOY/Dist-CheckConflicts-0.11.tar.gz
     provides:
@@ -2425,10 +2422,10 @@ DISTRIBUTIONS
       base 0
       strict 0
       warnings 0
-  EV-4.36
-    pathname: M/ML/MLEHMANN/EV-4.36.tar.gz
+  EV-4.37
+    pathname: M/ML/MLEHMANN/EV-4.37.tar.gz
     provides:
-      EV 4.36
+      EV 4.37
       EV::MakeMaker undef
     requirements:
       Canary::Stability 0
@@ -2724,103 +2721,78 @@ DISTRIBUTIONS
       perl 5.008001
       strict 0
       warnings 0
-  Exporter-Tiny-1.006002
-    pathname: T/TO/TOBYINK/Exporter-Tiny-1.006002.tar.gz
+  Exporter-Tiny-1.006003
+    pathname: T/TO/TOBYINK/Exporter-Tiny-1.006003.tar.gz
     provides:
-      Exporter::Shiny 1.006002
-      Exporter::Tiny 1.006002
+      Exporter::Shiny 1.006003
+      Exporter::Tiny 1.006003
     requirements:
       ExtUtils::MakeMaker 6.17
       perl 5.006001
-  ExtUtils-Builder-0.018
-    pathname: L/LE/LEONT/ExtUtils-Builder-0.018.tar.gz
+  ExtUtils-Builder-0.020
+    pathname: L/LE/LEONT/ExtUtils-Builder-0.020.tar.gz
     provides:
-      ExtUtils::Builder 0.018
-      ExtUtils::Builder::Action 0.018
-      ExtUtils::Builder::Action::Code 0.018
-      ExtUtils::Builder::Action::Command 0.018
-      ExtUtils::Builder::Action::Composite 0.018
-      ExtUtils::Builder::Action::Function 0.018
-      ExtUtils::Builder::Action::Perl 0.018
-      ExtUtils::Builder::Action::Primitive 0.018
-      ExtUtils::Builder::FileSet 0.018
-      ExtUtils::Builder::FileSet::Filter 0.018
-      ExtUtils::Builder::FileSet::Free 0.018
-      ExtUtils::Builder::FileSet::Subst 0.018
-      ExtUtils::Builder::MakeMaker 0.018
-      ExtUtils::Builder::Node 0.018
-      ExtUtils::Builder::Plan 0.018
-      ExtUtils::Builder::Planner 0.018
-      ExtUtils::Builder::Planner::Extension 0.018
-      ExtUtils::Builder::Serializer 0.018
-      ExtUtils::Builder::Util 0.018
+      ExtUtils::Builder 0.020
+      ExtUtils::Builder::Action 0.020
+      ExtUtils::Builder::Action::Code 0.020
+      ExtUtils::Builder::Action::Command 0.020
+      ExtUtils::Builder::Action::Composite 0.020
+      ExtUtils::Builder::Action::Function 0.020
+      ExtUtils::Builder::Action::Perl 0.020
+      ExtUtils::Builder::Action::Primitive 0.020
+      ExtUtils::Builder::CPAN::Tool 0.020
+      ExtUtils::Builder::FileSet 0.020
+      ExtUtils::Builder::FileSet::Filter 0.020
+      ExtUtils::Builder::FileSet::Free 0.020
+      ExtUtils::Builder::FileSet::Subst 0.020
+      ExtUtils::Builder::MakeMaker 0.020
+      ExtUtils::Builder::Node 0.020
+      ExtUtils::Builder::Plan 0.020
+      ExtUtils::Builder::Planner 0.020
+      ExtUtils::Builder::Planner::Extension 0.020
+      ExtUtils::Builder::Serializer 0.020
+      ExtUtils::Builder::Util 0.020
     requirements:
-      Carp 0
-      Data::Dumper 0
-      Exporter 5.57
-      ExtUtils::Config 0
-      ExtUtils::Config::MakeMaker 0
+      CPAN::Meta 0
+      ExtUtils::Config 0.009
       ExtUtils::Helpers 0.027
       ExtUtils::MakeMaker 6.68
-      ExtUtils::Manifest 0
-      File::Basename 0
-      File::Spec 0
-      File::Spec::Unix 0
       List::Util 1.45
       Perl::OSType 0
-      Scalar::Util 0
-      base 0
       parent 0
       perl 5.010
-      strict 0
-      version 0
-      warnings 0
-  ExtUtils-Builder-Compiler-0.032
-    pathname: L/LE/LEONT/ExtUtils-Builder-Compiler-0.032.tar.gz
+  ExtUtils-Builder-Compiler-0.037
+    pathname: L/LE/LEONT/ExtUtils-Builder-Compiler-0.037.tar.gz
     provides:
-      ExtUtils::Builder::ArgumentCollector 0.032
-      ExtUtils::Builder::AutoDetect::C 0.032
-      ExtUtils::Builder::AutoDetect::Cpp 0.032
-      ExtUtils::Builder::Binary 0.032
-      ExtUtils::Builder::Compiler 0.032
-      ExtUtils::Builder::Compiler::MSVC 0.032
-      ExtUtils::Builder::Compiler::Unixy 0.032
-      ExtUtils::Builder::Compiler::VMS 0.032
-      ExtUtils::Builder::Conf 0.032
-      ExtUtils::Builder::Linker 0.032
-      ExtUtils::Builder::Linker::Ar 0.032
-      ExtUtils::Builder::Linker::COFF 0.032
-      ExtUtils::Builder::Linker::ELF::Any 0.032
-      ExtUtils::Builder::Linker::ELF::GCC 0.032
-      ExtUtils::Builder::Linker::Mach::GCC 0.032
-      ExtUtils::Builder::Linker::PE::GCC 0.032
-      ExtUtils::Builder::Linker::PE::MSVC 0.032
-      ExtUtils::Builder::Linker::Unixy 0.032
-      ExtUtils::Builder::Linker::XCOFF 0.032
-      ExtUtils::Builder::MultiLingual 0.032
-      ExtUtils::Builder::ParseXS 0.032
-      ExtUtils::Builder::Profile::Perl 0.032
+      ExtUtils::Builder::ArgumentCollector 0.037
+      ExtUtils::Builder::AutoDetect::C 0.037
+      ExtUtils::Builder::Binary 0.037
+      ExtUtils::Builder::BuildTools::Base 0.037
+      ExtUtils::Builder::BuildTools::FromPerl 0.037
+      ExtUtils::Builder::Compiler 0.037
+      ExtUtils::Builder::Compiler::MSVC 0.037
+      ExtUtils::Builder::Compiler::Unixy 0.037
+      ExtUtils::Builder::Compiler::VMS 0.037
+      ExtUtils::Builder::Conf 0.037
+      ExtUtils::Builder::Linker 0.037
+      ExtUtils::Builder::Linker::Ar 0.037
+      ExtUtils::Builder::Linker::COFF 0.037
+      ExtUtils::Builder::Linker::ELF::Any 0.037
+      ExtUtils::Builder::Linker::ELF::GCC 0.037
+      ExtUtils::Builder::Linker::Mach::GCC 0.037
+      ExtUtils::Builder::Linker::PE::GCC 0.037
+      ExtUtils::Builder::Linker::PE::MSVC 0.037
+      ExtUtils::Builder::Linker::Unixy 0.037
+      ExtUtils::Builder::Linker::XCOFF 0.037
+      ExtUtils::Builder::ParseXS 0.037
+      ExtUtils::Builder::Profile::Perl 0.037
     requirements:
-      Carp 0
-      DynaLoader 0
-      ExtUtils::Builder 0.016
-      ExtUtils::Builder::Action::Command 0
-      ExtUtils::Builder::Node 0
-      ExtUtils::Builder::Planner 0.007
-      ExtUtils::Builder::Planner::Extension 0
-      ExtUtils::Builder::Util 0
+      ExtUtils::Builder 0.018
       ExtUtils::Config 0.007
-      ExtUtils::Helpers 0.027
       ExtUtils::MakeMaker 0
-      File::Basename 0
-      File::Spec::Functions 0
-      File::Temp 0
       Perl::OSType 0
       parent 0
       perl 5.010
-      sort 0
-      strict 0
-      warnings 0
   ExtUtils-CChecker-0.12
     pathname: P/PE/PEVANS/ExtUtils-CChecker-0.12.tar.gz
     provides:
@@ -2895,58 +2867,58 @@ DISTRIBUTIONS
       File::Which 0
       List::Util 1.33
       perl 5.006
-  FFI-Platypus-2.10
-    pathname: P/PL/PLICEASE/FFI-Platypus-2.10.tar.gz
+  FFI-Platypus-2.11
+    pathname: P/PL/PLICEASE/FFI-Platypus-2.11.tar.gz
     provides:
-      FFI::Build 2.10
-      FFI::Build::File::Base 2.10
-      FFI::Build::File::C 2.10
-      FFI::Build::File::CXX 2.10
-      FFI::Build::File::Library 2.10
-      FFI::Build::File::Object 2.10
-      FFI::Build::MM 2.10
-      FFI::Build::MM::FBX 2.10
-      FFI::Build::Platform 2.10
-      FFI::Build::Plugin 2.10
+      FFI::Build 2.11
+      FFI::Build::File::Base 2.11
+      FFI::Build::File::C 2.11
+      FFI::Build::File::CXX 2.11
+      FFI::Build::File::Library 2.11
+      FFI::Build::File::Object 2.11
+      FFI::Build::MM 2.11
+      FFI::Build::MM::FBX 2.11
+      FFI::Build::Platform 2.11
+      FFI::Build::Plugin 2.11
       FFI::Build::Plugin::Foo1 undef
       FFI::Build::Plugin::Foo2 undef
-      FFI::Build::PluginData 2.10
-      FFI::Platypus 2.10
-      FFI::Platypus::API 2.10
-      FFI::Platypus::Buffer 2.10
-      FFI::Platypus::Bundle 2.10
-      FFI::Platypus::Closure 2.10
-      FFI::Platypus::ClosureData 2.10
-      FFI::Platypus::Constant 2.10
-      FFI::Platypus::DL 2.10
-      FFI::Platypus::Function 2.10
-      FFI::Platypus::Function::Function 2.10
-      FFI::Platypus::Function::Wrapper 2.10
-      FFI::Platypus::Internal 2.10
-      FFI::Platypus::Lang 2.10
-      FFI::Platypus::Lang::ASM 2.10
-      FFI::Platypus::Lang::C 2.10
-      FFI::Platypus::Lang::Win32 2.10
-      FFI::Platypus::Legacy 2.10
-      FFI::Platypus::Memory 2.10
-      FFI::Platypus::Record 2.10
-      FFI::Platypus::Record::Meta 2.10
-      FFI::Platypus::Record::TieArray 2.10
-      FFI::Platypus::ShareConfig 2.10
-      FFI::Platypus::Type 2.10
-      FFI::Platypus::Type::PointerSizeBuffer 2.10
-      FFI::Platypus::Type::StringArray 2.10
-      FFI::Platypus::Type::StringPointer 2.10
-      FFI::Platypus::Type::WideString 2.10
-      FFI::Platypus::TypeParser 2.10
-      FFI::Platypus::TypeParser::Version0 2.10
-      FFI::Platypus::TypeParser::Version1 2.10
-      FFI::Platypus::TypeParser::Version2 2.10
-      FFI::Probe 2.10
-      FFI::Probe::Runner 2.10
-      FFI::Probe::Runner::Builder 2.10
-      FFI::Probe::Runner::Result 2.10
-      FFI::Temp 2.10
+      FFI::Build::PluginData 2.11
+      FFI::Platypus 2.11
+      FFI::Platypus::API 2.11
+      FFI::Platypus::Buffer 2.11
+      FFI::Platypus::Bundle 2.11
+      FFI::Platypus::Closure 2.11
+      FFI::Platypus::ClosureData 2.11
+      FFI::Platypus::Constant 2.11
+      FFI::Platypus::DL 2.11
+      FFI::Platypus::Function 2.11
+      FFI::Platypus::Function::Function 2.11
+      FFI::Platypus::Function::Wrapper 2.11
+      FFI::Platypus::Internal 2.11
+      FFI::Platypus::Lang 2.11
+      FFI::Platypus::Lang::ASM 2.11
+      FFI::Platypus::Lang::C 2.11
+      FFI::Platypus::Lang::Win32 2.11
+      FFI::Platypus::Legacy 2.11
+      FFI::Platypus::Memory 2.11
+      FFI::Platypus::Record 2.11
+      FFI::Platypus::Record::Meta 2.11
+      FFI::Platypus::Record::TieArray 2.11
+      FFI::Platypus::ShareConfig 2.11
+      FFI::Platypus::Type 2.11
+      FFI::Platypus::Type::PointerSizeBuffer 2.11
+      FFI::Platypus::Type::StringArray 2.11
+      FFI::Platypus::Type::StringPointer 2.11
+      FFI::Platypus::Type::WideString 2.11
+      FFI::Platypus::TypeParser 2.11
+      FFI::Platypus::TypeParser::Version0 2.11
+      FFI::Platypus::TypeParser::Version1 2.11
+      FFI::Platypus::TypeParser::Version2 2.11
+      FFI::Probe 2.11
+      FFI::Probe::Runner 2.11
+      FFI::Probe::Runner::Builder 2.11
+      FFI::Probe::Runner::Result 2.11
+      FFI::Temp 2.11
     requirements:
       Capture::Tiny 0
       ExtUtils::CBuilder 0
@@ -2982,10 +2954,10 @@ DISTRIBUTIONS
       File::Copy 0
       File::Glob 0
       File::Spec 0
-  File-DesktopEntry-0.22
-    pathname: M/MI/MICHIELB/File-DesktopEntry-0.22.tar.gz
+  File-DesktopEntry-0.23
+    pathname: M/MI/MICHIELB/File-DesktopEntry-0.23.tar.gz
     provides:
-      File::DesktopEntry 0.22
+      File::DesktopEntry 0.23
     requirements:
       Carp 0
       Encode 0
@@ -3048,13 +3020,13 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       HTTP::Date 0
       perl 5.006
-  File-MimeInfo-0.35
-    pathname: M/MI/MICHIELB/File-MimeInfo-0.35.tar.gz
+  File-MimeInfo-0.37
+    pathname: M/MI/MICHIELB/File-MimeInfo-0.37.tar.gz
     provides:
-      File::MimeInfo 0.35
-      File::MimeInfo::Applications 0.35
-      File::MimeInfo::Magic 0.35
-      File::MimeInfo::Rox 0.35
+      File::MimeInfo 0.37
+      File::MimeInfo::Applications 0.37
+      File::MimeInfo::Magic 0.37
+      File::MimeInfo::Rox 0.37
     requirements:
       Carp 0
       Encode::Locale 0
@@ -3189,12 +3161,12 @@ DISTRIBUTIONS
       Test::Builder::Module 0
       Time::HiRes 0
       perl 5.014
-  GD-2.83
-    pathname: R/RU/RURBAN/GD-2.83.tar.gz
+  GD-2.86
+    pathname: R/RU/RURBAN/GD-2.86.tar.gz
     provides:
-      GD 2.83
+      GD 2.86
       GD::Group 1
-      GD::Image 2.83
+      GD::Image 2.86
       GD::Polygon 2.82
       GD::Polyline 0.2
       GD::Simple undef
@@ -3385,40 +3357,59 @@ DISTRIBUTIONS
       Moose 0
       Moose::Util::TypeConstraints 0
       Text::Flow 0
-  Graphics-Toolkit-Color-1.972
-    pathname: L/LI/LICHTKIND/Graphics-Toolkit-Color-1.972.tar.gz
+  Graphics-Toolkit-Color-2.22
+    pathname: L/LI/LICHTKIND/Graphics-Toolkit-Color-2.22.tar.gz
     provides:
-      Graphics::Toolkit::Color 1.972
-      Graphics::Toolkit::Color::Name 1.972
-      Graphics::Toolkit::Color::Name::Constant 1.972
-      Graphics::Toolkit::Color::Name::Scheme 1.972
-      Graphics::Toolkit::Color::SetCalculator 1.972
-      Graphics::Toolkit::Color::Space 1.972
-      Graphics::Toolkit::Color::Space::Basis 1.972
-      Graphics::Toolkit::Color::Space::Format 1.972
-      Graphics::Toolkit::Color::Space::Hub 1.972
-      Graphics::Toolkit::Color::Space::Instance::CIELAB 1.972
-      Graphics::Toolkit::Color::Space::Instance::CIELCHab 1.972
-      Graphics::Toolkit::Color::Space::Instance::CIELCHuv 1.972
-      Graphics::Toolkit::Color::Space::Instance::CIELUV 1.972
-      Graphics::Toolkit::Color::Space::Instance::CIEXYZ 1.972
-      Graphics::Toolkit::Color::Space::Instance::CMY 1.972
-      Graphics::Toolkit::Color::Space::Instance::CMYK 1.972
-      Graphics::Toolkit::Color::Space::Instance::HSB 1.972
-      Graphics::Toolkit::Color::Space::Instance::HSL 1.972
-      Graphics::Toolkit::Color::Space::Instance::HSV 1.972
-      Graphics::Toolkit::Color::Space::Instance::HWB 1.972
-      Graphics::Toolkit::Color::Space::Instance::HunterLAB 1.972
-      Graphics::Toolkit::Color::Space::Instance::NCol 1.972
-      Graphics::Toolkit::Color::Space::Instance::OKLAB 1.972
-      Graphics::Toolkit::Color::Space::Instance::OKLCH 1.972
-      Graphics::Toolkit::Color::Space::Instance::RGB 1.972
-      Graphics::Toolkit::Color::Space::Instance::YIQ 1.972
-      Graphics::Toolkit::Color::Space::Instance::YUV 1.972
-      Graphics::Toolkit::Color::Space::Shape 1.972
-      Graphics::Toolkit::Color::Space::Util 1.972
-      Graphics::Toolkit::Color::Values 1.972
+      Graphics::Toolkit::Color 2.22
+      Graphics::Toolkit::Color::Calculator 2.22
+      Graphics::Toolkit::Color::Error 2.22
+      Graphics::Toolkit::Color::Name 2.22
+      Graphics::Toolkit::Color::Name::Constant 2.22
+      Graphics::Toolkit::Color::Name::Scheme 2.22
+      Graphics::Toolkit::Color::SetCalculator 2.22
+      Graphics::Toolkit::Color::Space 2.22
+      Graphics::Toolkit::Color::Space::Basis 2.22
+      Graphics::Toolkit::Color::Space::Format 2.22
+      Graphics::Toolkit::Color::Space::Hub 2.22
+      Graphics::Toolkit::Color::Space::Instance::AdobeRGB 2.22
+      Graphics::Toolkit::Color::Space::Instance::AppleRGB 2.22
+      Graphics::Toolkit::Color::Space::Instance::CIELAB 2.22
+      Graphics::Toolkit::Color::Space::Instance::CIELCHab 2.22
+      Graphics::Toolkit::Color::Space::Instance::CIELCHuv 2.22
+      Graphics::Toolkit::Color::Space::Instance::CIELUV 2.22
+      Graphics::Toolkit::Color::Space::Instance::CIERGB 2.22
+      Graphics::Toolkit::Color::Space::Instance::CIEXYZ 2.22
+      Graphics::Toolkit::Color::Space::Instance::CMY 2.22
+      Graphics::Toolkit::Color::Space::Instance::CMYK 2.22
+      Graphics::Toolkit::Color::Space::Instance::DCIP3 2.22
+      Graphics::Toolkit::Color::Space::Instance::DCIP3Linear 2.22
+      Graphics::Toolkit::Color::Space::Instance::DisplayP3 2.22
+      Graphics::Toolkit::Color::Space::Instance::DisplayP3Linear 2.22
+      Graphics::Toolkit::Color::Space::Instance::HSB 2.22
+      Graphics::Toolkit::Color::Space::Instance::HSL 2.22
+      Graphics::Toolkit::Color::Space::Instance::HSV 2.22
+      Graphics::Toolkit::Color::Space::Instance::HWB 2.22
+      Graphics::Toolkit::Color::Space::Instance::Helper::OK 2.22
+      Graphics::Toolkit::Color::Space::Instance::HunterLAB 2.22
+      Graphics::Toolkit::Color::Space::Instance::NCol 2.22
+      Graphics::Toolkit::Color::Space::Instance::OKHSL 2.22
+      Graphics::Toolkit::Color::Space::Instance::OKHSV 2.22
+      Graphics::Toolkit::Color::Space::Instance::OKHWB 2.22
+      Graphics::Toolkit::Color::Space::Instance::OKLAB 2.22
+      Graphics::Toolkit::Color::Space::Instance::OKLCH 2.22
+      Graphics::Toolkit::Color::Space::Instance::ProPhotoRGB 2.22
+      Graphics::Toolkit::Color::Space::Instance::RGB 2.22
+      Graphics::Toolkit::Color::Space::Instance::RGBLinear 2.22
+      Graphics::Toolkit::Color::Space::Instance::Rec2020 2.22
+      Graphics::Toolkit::Color::Space::Instance::Rec709 2.22
+      Graphics::Toolkit::Color::Space::Instance::WideGamutRGB 2.22
+      Graphics::Toolkit::Color::Space::Instance::YIQ 2.22
+      Graphics::Toolkit::Color::Space::Instance::YPbPr 2.22
+      Graphics::Toolkit::Color::Space::Shape 2.22
+      Graphics::Toolkit::Color::Space::Util 2.22
+      Graphics::Toolkit::Color::Values 2.22
     requirements:
+      Carp 1
       Exporter 5
       ExtUtils::MakeMaker 0
       perl 5.012000
@@ -3438,16 +3429,16 @@ DISTRIBUTIONS
       XSLoader 0
       parent 0
       perl 5.008008
-  HTML-Parser-3.83
-    pathname: O/OA/OALDERS/HTML-Parser-3.83.tar.gz
+  HTML-Parser-3.85
+    pathname: O/OA/OALDERS/HTML-Parser-3.85.tar.gz
     provides:
-      HTML::Entities 3.83
-      HTML::Filter 3.83
-      HTML::HeadParser 3.83
-      HTML::LinkExtor 3.83
-      HTML::Parser 3.83
-      HTML::PullParser 3.83
-      HTML::TokeParser 3.83
+      HTML::Entities 3.85
+      HTML::Filter 3.85
+      HTML::HeadParser 3.85
+      HTML::LinkExtor 3.85
+      HTML::Parser 3.85
+      HTML::PullParser 3.85
+      HTML::TokeParser 3.85
     requirements:
       Carp 0
       Exporter 0
@@ -3517,10 +3508,10 @@ DISTRIBUTIONS
       locale 0
       perl 5.008001
       strict 0
-  HTTP-Date-6.06
-    pathname: O/OA/OALDERS/HTTP-Date-6.06.tar.gz
+  HTTP-Date-6.08
+    pathname: O/OA/OALDERS/HTTP-Date-6.08.tar.gz
     provides:
-      HTTP::Date 6.06
+      HTTP::Date 6.08
     requirements:
       Exporter 0
       ExtUtils::MakeMaker 0
@@ -3555,19 +3546,19 @@ DISTRIBUTIONS
       HTTP::Date 0
       Module::Build::Tiny 0.035
       perl 5.008001
-  HTTP-Message-7.01
-    pathname: O/OA/OALDERS/HTTP-Message-7.01.tar.gz
+  HTTP-Message-7.02
+    pathname: O/OA/OALDERS/HTTP-Message-7.02.tar.gz
     provides:
-      HTTP::Config 7.01
-      HTTP::Headers 7.01
-      HTTP::Headers::Auth 7.01
-      HTTP::Headers::ETag 7.01
-      HTTP::Headers::Util 7.01
-      HTTP::Message 7.01
-      HTTP::Request 7.01
-      HTTP::Request::Common 7.01
-      HTTP::Response 7.01
-      HTTP::Status 7.01
+      HTTP::Config 7.02
+      HTTP::Headers 7.02
+      HTTP::Headers::Auth 7.02
+      HTTP::Headers::ETag 7.02
+      HTTP::Headers::Util 7.02
+      HTTP::Message 7.02
+      HTTP::Request 7.02
+      HTTP::Request::Common 7.02
+      HTTP::Response 7.02
+      HTTP::Status 7.02
     requirements:
       Carp 0
       Clone 0.46
@@ -3658,46 +3649,46 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       Test::Simple 0.45
-  IO-Async-0.804
-    pathname: P/PE/PEVANS/IO-Async-0.804.tar.gz
+  IO-Async-0.805
+    pathname: P/PE/PEVANS/IO-Async-0.805.tar.gz
     provides:
-      Future::IO::Impl::IOAsync 0.804
-      IO::Async 0.804
-      IO::Async::Channel 0.804
-      IO::Async::Debug 0.804
-      IO::Async::File 0.804
-      IO::Async::FileStream 0.804
-      IO::Async::Function 0.804
-      IO::Async::Future 0.804
-      IO::Async::Handle 0.804
-      IO::Async::Internals::ChildManager 0.804
-      IO::Async::Internals::FunctionWorker 0.804
-      IO::Async::Listener 0.804
-      IO::Async::Loop 0.804
-      IO::Async::Loop::Poll 0.804
-      IO::Async::Loop::Select 0.804
-      IO::Async::LoopTests 0.804
-      IO::Async::Metrics 0.804
-      IO::Async::Notifier 0.804
-      IO::Async::OS 0.804
-      IO::Async::OS::MSWin32 0.804
-      IO::Async::OS::cygwin 0.804
-      IO::Async::OS::linux 0.804
-      IO::Async::PID 0.804
-      IO::Async::Process 0.804
-      IO::Async::Protocol 0.804
-      IO::Async::Protocol::LineStream 0.804
-      IO::Async::Protocol::Stream 0.804
-      IO::Async::Resolver 0.804
-      IO::Async::Routine 0.804
-      IO::Async::Signal 0.804
-      IO::Async::Socket 0.804
-      IO::Async::Stream 0.804
-      IO::Async::Test 0.804
-      IO::Async::Timer 0.804
-      IO::Async::Timer::Absolute 0.804
-      IO::Async::Timer::Countdown 0.804
-      IO::Async::Timer::Periodic 0.804
+      Future::IO::Impl::IOAsync 0.805
+      IO::Async 0.805
+      IO::Async::Channel 0.805
+      IO::Async::Debug 0.805
+      IO::Async::File 0.805
+      IO::Async::FileStream 0.805
+      IO::Async::Function 0.805
+      IO::Async::Future 0.805
+      IO::Async::Handle 0.805
+      IO::Async::Internals::ChildManager 0.805
+      IO::Async::Internals::FunctionWorker 0.805
+      IO::Async::Listener 0.805
+      IO::Async::Loop 0.805
+      IO::Async::Loop::Poll 0.805
+      IO::Async::Loop::Select 0.805
+      IO::Async::LoopTests 0.805
+      IO::Async::Metrics 0.805
+      IO::Async::Notifier 0.805
+      IO::Async::OS 0.805
+      IO::Async::OS::MSWin32 0.805
+      IO::Async::OS::cygwin 0.805
+      IO::Async::OS::linux 0.805
+      IO::Async::PID 0.805
+      IO::Async::Process 0.805
+      IO::Async::Protocol 0.805
+      IO::Async::Protocol::LineStream 0.805
+      IO::Async::Protocol::Stream 0.805
+      IO::Async::Resolver 0.805
+      IO::Async::Routine 0.805
+      IO::Async::Signal 0.805
+      IO::Async::Socket 0.805
+      IO::Async::Stream 0.805
+      IO::Async::Test 0.805
+      IO::Async::Timer 0.805
+      IO::Async::Timer::Absolute 0.805
+      IO::Async::Timer::Countdown 0.805
+      IO::Async::Timer::Periodic 0.805
     requirements:
       Exporter 5.57
       File::stat 0
@@ -3748,18 +3739,18 @@ DISTRIBUTIONS
       IO::SessionSet undef
     requirements:
       ExtUtils::MakeMaker 0
-  IO-Socket-SSL-2.095
-    pathname: S/SU/SULLR/IO-Socket-SSL-2.095.tar.gz
+  IO-Socket-SSL-2.099
+    pathname: S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz
     provides:
-      IO::Socket::SSL 2.095
+      IO::Socket::SSL 2.099
       IO::Socket::SSL::Intercept 2.056
-      IO::Socket::SSL::OCSP_Cache 2.095
-      IO::Socket::SSL::OCSP_Resolver 2.095
+      IO::Socket::SSL::OCSP_Cache 2.099
+      IO::Socket::SSL::OCSP_Resolver 2.099
       IO::Socket::SSL::PublicSuffix undef
-      IO::Socket::SSL::SSL_Context 2.095
-      IO::Socket::SSL::SSL_HANDLE 2.095
-      IO::Socket::SSL::Session_Cache 2.095
-      IO::Socket::SSL::Trace 2.095
+      IO::Socket::SSL::SSL_Context 2.099
+      IO::Socket::SSL::SSL_HANDLE 2.099
+      IO::Socket::SSL::Session_Cache 2.099
+      IO::Socket::SSL::Trace 2.099
       IO::Socket::SSL::Utils 2.015
     requirements:
       ExtUtils::MakeMaker 0
@@ -3811,18 +3802,19 @@ DISTRIBUTIONS
       re 0
       strict 0
       warnings 0
-  JSON-4.10
-    pathname: I/IS/ISHIGAKI/JSON-4.10.tar.gz
+  JSON-4.11
+    pathname: I/IS/ISHIGAKI/JSON-4.11.tar.gz
     provides:
-      JSON 4.10
-      JSON::Backend::PP 4.10
+      JSON 4.11
+      JSON::Backend::PP 4.11
     requirements:
       ExtUtils::MakeMaker 0
-      Test::More 0
-  JSON-Any-1.40
-    pathname: E/ET/ETHER/JSON-Any-1.40.tar.gz
+      Scalar::Util 1.08
+      Test::More 0.88
+  JSON-Any-1.42
+    pathname: E/ET/ETHER/JSON-Any-1.42.tar.gz
     provides:
-      JSON::Any 1.40
+      JSON::Any 1.42
     requirements:
       CPAN::Meta::Requirements 2.120620
       Carp 0
@@ -3875,10 +3867,10 @@ DISTRIBUTIONS
       Router::Simple 0
       Test::More 0
       parent 0
-  JSON-Validator-5.15
-    pathname: J/JH/JHTHORSEN/JSON-Validator-5.15.tar.gz
+  JSON-Validator-5.19
+    pathname: J/JH/JHTHORSEN/JSON-Validator-5.19.tar.gz
     provides:
-      JSON::Validator 5.15
+      JSON::Validator 5.19
       JSON::Validator::Error undef
       JSON::Validator::Formats undef
       JSON::Validator::Joi undef
@@ -3893,9 +3885,12 @@ DISTRIBUTIONS
       JSON::Validator::URI undef
       JSON::Validator::Util undef
     requirements:
+      Data::Validate::Domain 0.11
+      Data::Validate::IP 0.27
       ExtUtils::MakeMaker 0
       List::Util 1.45
-      Mojolicious 7.28
+      Mojolicious 9.34
+      Net::IDN::Encode 2.500
       YAML::XS 0.67
       perl 5.016
   JSON-XS-4.04
@@ -3919,11 +3914,11 @@ DISTRIBUTIONS
       Scalar::Util 0
       perl 5.006002
       strict 0
-  LWP-Protocol-https-6.14
-    pathname: O/OA/OALDERS/LWP-Protocol-https-6.14.tar.gz
+  LWP-Protocol-https-6.15
+    pathname: O/OA/OALDERS/LWP-Protocol-https-6.15.tar.gz
     provides:
-      LWP::Protocol::https 6.14
-      LWP::Protocol::https::Socket 6.14
+      LWP::Protocol::https 6.15
+      LWP::Protocol::https::Socket 6.15
     requirements:
       ExtUtils::MakeMaker 0
       IO::Socket::SSL 1.970
@@ -4009,32 +4004,6 @@ DISTRIBUTIONS
       IPC::Cmd 0
       XSLoader 0.22
       base 0
-  List-SomeUtils-0.59
-    pathname: D/DR/DROLSKY/List-SomeUtils-0.59.tar.gz
-    provides:
-      List::SomeUtils 0.59
-      List::SomeUtils::PP 0.59
-    requirements:
-      Carp 0
-      Exporter 0
-      ExtUtils::MakeMaker 0
-      List::SomeUtils::XS 0.54
-      List::Util 0
-      Module::Implementation 0.04
-      Text::ParseWords 0
-      perl 5.006
-      strict 0
-      vars 0
-      warnings 0
-  List-SomeUtils-XS-0.58
-    pathname: D/DR/DROLSKY/List-SomeUtils-XS-0.58.tar.gz
-    provides:
-      List::SomeUtils::XS 0.58
-    requirements:
-      ExtUtils::MakeMaker 0
-      XSLoader 0
-      strict 0
-      warnings 0
   Log-Dispatch-2.71
     pathname: D/DR/DROLSKY/Log-Dispatch-2.71.tar.gz
     provides:
@@ -4176,51 +4145,50 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 6.42
       Test::More 0
       perl 5.005
-  MIME-Types-2.29
-    pathname: M/MA/MARKOV/MIME-Types-2.29.tar.gz
+  MIME-Types-2.30
+    pathname: M/MA/MARKOV/MIME-Types-2.30.tar.gz
     provides:
-      MIME::Type 2.29
-      MIME::Types 2.29
-      MojoX::MIME::Types 2.29
+      MIME::Type 2.30
+      MIME::Types 2.30
+      MojoX::MIME::Types 2.30
     requirements:
       ExtUtils::MakeMaker 0
       File::Basename 0
       File::Spec 0
       List::Util 0
-      Test::More 0.47
-  MIME-tools-5.515
-    pathname: D/DS/DSKOLL/MIME-tools-5.515.tar.gz
+  MIME-tools-5.517
+    pathname: D/DS/DSKOLL/MIME-tools-5.517.tar.gz
     provides:
-      MIME::Body 5.515
-      MIME::Body::File 5.515
-      MIME::Body::InCore 5.515
-      MIME::Body::Scalar 5.515
-      MIME::Decoder 5.515
-      MIME::Decoder::Base64 5.515
-      MIME::Decoder::BinHex 5.515
-      MIME::Decoder::Binary 5.515
-      MIME::Decoder::Gzip64 5.515
-      MIME::Decoder::NBit 5.515
-      MIME::Decoder::QuotedPrint 5.515
-      MIME::Decoder::UU 5.515
-      MIME::Entity 5.515
-      MIME::Field::ConTraEnc 5.515
-      MIME::Field::ContDisp 5.515
-      MIME::Field::ContType 5.515
-      MIME::Field::ParamVal 5.515
-      MIME::Head 5.515
-      MIME::Parser 5.515
+      MIME::Body 5.517
+      MIME::Body::File 5.517
+      MIME::Body::InCore 5.517
+      MIME::Body::Scalar 5.517
+      MIME::Decoder 5.517
+      MIME::Decoder::Base64 5.517
+      MIME::Decoder::BinHex 5.517
+      MIME::Decoder::Binary 5.517
+      MIME::Decoder::Gzip64 5.517
+      MIME::Decoder::NBit 5.517
+      MIME::Decoder::QuotedPrint 5.517
+      MIME::Decoder::UU 5.517
+      MIME::Entity 5.517
+      MIME::Field::ConTraEnc 5.517
+      MIME::Field::ContDisp 5.517
+      MIME::Field::ContType 5.517
+      MIME::Field::ParamVal 5.517
+      MIME::Head 5.517
+      MIME::Parser 5.517
       MIME::Parser::FileInto undef
       MIME::Parser::FileUnder undef
       MIME::Parser::Filer undef
       MIME::Parser::Reader undef
       MIME::Parser::Results undef
-      MIME::Tools 5.515
+      MIME::Tools 5.517
       MIME::WordDecoder undef
       MIME::WordDecoder::ISO_8859 undef
       MIME::WordDecoder::US_ASCII undef
       MIME::WordDecoder::UTF_8 undef
-      MIME::Words 5.515
+      MIME::Words 5.517
     requirements:
       ExtUtils::MakeMaker 6.59
       File::Path 1
@@ -4275,28 +4243,51 @@ DISTRIBUTIONS
       Net::Domain 1.05
       Net::SMTP 1.28
       Test::More 0
-  Math-Prime-Util-0.73
-    pathname: D/DA/DANAJ/Math-Prime-Util-0.73.tar.gz
+  Math-BigInt-GMP-1.7003
+    pathname: P/PJ/PJACKLAM/Math-BigInt-GMP-1.7003.tar.gz
     provides:
-      Math::Prime::Util 0.73
-      Math::Prime::Util::ChaCha 0.73
-      Math::Prime::Util::Entropy 0.73
-      Math::Prime::Util::MemFree 0.73
-      Math::Prime::Util::PP 0.73
-      Math::Prime::Util::PrimeArray 0.73
-      Math::Prime::Util::PrimeIterator 0.73
-      ntheory 0.73
+      Math::BigInt::GMP 1.7003
+    requirements:
+      Carp 1.22
+      ExtUtils::MakeMaker 6.58
+      Math::BigInt 2.005001
+      XSLoader 0.02
+      perl 5.008
+  Math-Prime-Util-0.74
+    pathname: D/DA/DANAJ/Math-Prime-Util-0.74.tar.gz
+    provides:
+      Math::Prime::Util 0.74
+      Math::Prime::Util::ChaCha 0.74
+      Math::Prime::Util::Entropy 0.74
+      Math::Prime::Util::MemFree 0.74
+      Math::Prime::Util::PP 0.74
+      Math::Prime::Util::PrimeArray 0.74
+      Math::Prime::Util::PrimeIterator 0.74
+      ntheory 0.74
     requirements:
       Carp 0
       Config 0
       Exporter 5.57
       ExtUtils::MakeMaker 0
       Math::BigFloat 1.59
-      Math::BigInt 1.88
+      Math::BigInt 1.999814
+      Math::Prime::Util::GMP 0.50
       Tie::Array 0
       XSLoader 0.01
       base 0
       constant 0
+      perl 5.006002
+  Math-Prime-Util-GMP-0.53
+    pathname: D/DA/DANAJ/Math-Prime-Util-GMP-0.53.tar.gz
+    provides:
+      Math::Prime::Util::GMP 0.53
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      Fcntl 0
+      XSLoader 0.01
+      base 0
       perl 5.006002
   Math-Random-ISAAC-1.004
     pathname: J/JA/JAWNSY/Math-Random-ISAAC-1.004.tar.gz
@@ -4403,10 +4394,10 @@ DISTRIBUTIONS
       Test::Requires 0
       parent 0
       perl 5.008001
-  Module-Build-Tiny-0.052
-    pathname: L/LE/LEONT/Module-Build-Tiny-0.052.tar.gz
+  Module-Build-Tiny-0.053
+    pathname: L/LE/LEONT/Module-Build-Tiny-0.053.tar.gz
     provides:
-      Module::Build::Tiny 0.052
+      Module::Build::Tiny 0.053
     requirements:
       CPAN::Meta 0
       DynaLoader 0
@@ -4484,10 +4475,10 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Mojo-JWT-1.01
-    pathname: J/JB/JBERGER/Mojo-JWT-1.01.tar.gz
+  Mojo-JWT-1.02
+    pathname: J/JB/JBERGER/Mojo-JWT-1.02.tar.gz
     provides:
-      Mojo::JWT 1.01
+      Mojo::JWT 1.02
     requirements:
       CryptX 0.029
       Module::Build::Tiny 0
@@ -4503,8 +4494,8 @@ DISTRIBUTIONS
       Mojolicious 2
       Test::More 0.94
       perl 5.010001
-  Mojolicious-9.42
-    pathname: S/SR/SRI/Mojolicious-9.42.tar.gz
+  Mojolicious-9.48
+    pathname: S/SR/SRI/Mojolicious-9.48.tar.gz
     provides:
       Mojo undef
       Mojo::Asset undef
@@ -4574,7 +4565,7 @@ DISTRIBUTIONS
       Mojo::UserAgent::Transactor undef
       Mojo::Util undef
       Mojo::WebSocket undef
-      Mojolicious 9.42
+      Mojolicious 9.48
       Mojolicious::Command undef
       Mojolicious::Command::Author::cpanify undef
       Mojolicious::Command::Author::generate undef
@@ -5285,21 +5276,28 @@ DISTRIBUTIONS
       Mozilla::CA 20250602
     requirements:
       ExtUtils::MakeMaker 0
-  Net-DNS-1.53
-    pathname: N/NL/NLNETLABS/Net-DNS-1.53.tar.gz
+  Net-CIDR-0.27
+    pathname: M/MR/MRSAM/Net-CIDR-0.27.tar.gz
     provides:
-      Net::DNS 1.53
+      Net::CIDR 0.27
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+  Net-DNS-1.56
+    pathname: N/NL/NLNETLABS/Net-DNS-1.56.tar.gz
+    provides:
+      Net::DNS 1.56
       Net::DNS::Domain 2002
-      Net::DNS::DomainName 2005
-      Net::DNS::DomainName1035 2005
-      Net::DNS::DomainName2535 2005
-      Net::DNS::Header 2002
+      Net::DNS::DomainName 2054
+      Net::DNS::DomainName1035 2054
+      Net::DNS::DomainName2535 2054
+      Net::DNS::Header 2042
       Net::DNS::Mailbox 2002
       Net::DNS::Mailbox1035 2002
       Net::DNS::Mailbox2535 2002
       Net::DNS::Nameserver 2002
       Net::DNS::Packet 2003
-      Net::DNS::Parameters 2021
+      Net::DNS::Parameters 2054
       Net::DNS::Question 2002
       Net::DNS::RR 2037
       Net::DNS::RR::A 2003
@@ -5311,14 +5309,14 @@ DISTRIBUTIONS
       Net::DNS::RR::CAA 2003
       Net::DNS::RR::CDNSKEY 2003
       Net::DNS::RR::CDS 2003
-      Net::DNS::RR::CERT 2002
+      Net::DNS::RR::CERT 2042
       Net::DNS::RR::CNAME 2003
       Net::DNS::RR::CSYNC 2003
-      Net::DNS::RR::DELEG 2039
+      Net::DNS::RR::DELEG 2053
       Net::DNS::RR::DHCID 2003
       Net::DNS::RR::DNAME 2003
-      Net::DNS::RR::DNSKEY 2003
-      Net::DNS::RR::DS 2003
+      Net::DNS::RR::DNSKEY 2042
+      Net::DNS::RR::DS 2042
       Net::DNS::RR::DSYNC 2003
       Net::DNS::RR::EUI48 2003
       Net::DNS::RR::EUI64 2003
@@ -5347,34 +5345,34 @@ DISTRIBUTIONS
       Net::DNS::RR::NSEC3PARAM 2003
       Net::DNS::RR::NULL 2002
       Net::DNS::RR::OPENPGPKEY 2003
-      Net::DNS::RR::OPT 2005
-      Net::DNS::RR::OPT::CHAIN 2005
-      Net::DNS::RR::OPT::CLIENT_SUBNET 2005
-      Net::DNS::RR::OPT::COOKIE 2005
-      Net::DNS::RR::OPT::DAU 2005
-      Net::DNS::RR::OPT::DHU 2005
-      Net::DNS::RR::OPT::EXPIRE 2005
-      Net::DNS::RR::OPT::EXTENDED_ERROR 2005
-      Net::DNS::RR::OPT::KEY_TAG 2005
-      Net::DNS::RR::OPT::N3U 2005
-      Net::DNS::RR::OPT::NSID 2005
-      Net::DNS::RR::OPT::PADDING 2005
-      Net::DNS::RR::OPT::REPORT_CHANNEL 2005
-      Net::DNS::RR::OPT::TCP_KEEPALIVE 2005
-      Net::DNS::RR::OPT::ZONEVERSION 2005
+      Net::DNS::RR::OPT 2054
+      Net::DNS::RR::OPT::CHAIN 2054
+      Net::DNS::RR::OPT::CLIENT_SUBNET 2054
+      Net::DNS::RR::OPT::COOKIE 2054
+      Net::DNS::RR::OPT::DAU 2054
+      Net::DNS::RR::OPT::DHU 2054
+      Net::DNS::RR::OPT::EXPIRE 2054
+      Net::DNS::RR::OPT::EXTENDED_ERROR 2054
+      Net::DNS::RR::OPT::KEY_TAG 2054
+      Net::DNS::RR::OPT::N3U 2054
+      Net::DNS::RR::OPT::NSID 2054
+      Net::DNS::RR::OPT::PADDING 2054
+      Net::DNS::RR::OPT::REPORT_CHANNEL 2054
+      Net::DNS::RR::OPT::TCP_KEEPALIVE 2054
+      Net::DNS::RR::OPT::ZONEVERSION 2054
       Net::DNS::RR::PTR 2002
       Net::DNS::RR::PX 2003
       Net::DNS::RR::RESINFO 2003
       Net::DNS::RR::RP 2002
-      Net::DNS::RR::RRSIG 2003
+      Net::DNS::RR::RRSIG 2057
       Net::DNS::RR::RT 2003
-      Net::DNS::RR::SIG 2003
+      Net::DNS::RR::SIG 2057
       Net::DNS::RR::SMIMEA 2003
       Net::DNS::RR::SOA 2002
       Net::DNS::RR::SPF 2003
       Net::DNS::RR::SRV 2003
       Net::DNS::RR::SSHFP 2003
-      Net::DNS::RR::SVCB 2037
+      Net::DNS::RR::SVCB 2043
       Net::DNS::RR::TKEY 2035
       Net::DNS::RR::TLSA 2003
       Net::DNS::RR::TSIG 2003
@@ -5383,15 +5381,15 @@ DISTRIBUTIONS
       Net::DNS::RR::X25 2002
       Net::DNS::RR::ZONEMD 2003
       Net::DNS::Resolver 2017
-      Net::DNS::Resolver::Base 2031
+      Net::DNS::Resolver::Base 2057
       Net::DNS::Resolver::MSWin32 2002
       Net::DNS::Resolver::Recurse 2002
-      Net::DNS::Resolver::UNIX 2007
+      Net::DNS::Resolver::UNIX 2053
       Net::DNS::Resolver::android 2007
       Net::DNS::Resolver::cygwin 2002
       Net::DNS::Resolver::os2 2007
       Net::DNS::Resolver::os390 2007
-      Net::DNS::Text 2002
+      Net::DNS::Text 2043
       Net::DNS::Update 2017
       Net::DNS::ZoneFile 2002
       Net::DNS::ZoneFile::Generator 2002
@@ -5423,6 +5421,14 @@ DISTRIBUTIONS
       perl 5.008009
       strict 1.03
       warnings 1.0501
+  Net-Domain-TLD-1.75
+    pathname: A/AL/ALEXP/Net-Domain-TLD-1.75.tar.gz
+    provides:
+      Net::Domain::TLD 1.75
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      Storable 0
   Net-HTTP-6.24
     pathname: O/OA/OALDERS/Net-HTTP-6.24.tar.gz
     provides:
@@ -5441,6 +5447,18 @@ DISTRIBUTIONS
       perl 5.006002
       strict 0
       warnings 0
+  Net-IDN-Encode-2.501-TRIAL
+    pathname: E/ET/ETHER/Net-IDN-Encode-2.501-TRIAL.tar.gz
+    provides:
+      Net::IDN::Encode 2.501
+      Net::IDN::Punycode 2.501
+      Net::IDN::Punycode::PP 2.501
+      Net::IDN::UTS46 2.501
+      Net::IDN::UTS46::_Mapping 10
+    requirements:
+      ExtUtils::CBuilder 0
+      Unicode::Normalize 0
+      perl 5.008005
   Net-OAuth2-AuthorizationServer-0.28
     pathname: L/LE/LEEJO/Net-OAuth2-AuthorizationServer-0.28.tar.gz
     provides:
@@ -5476,11 +5494,11 @@ DISTRIBUTIONS
       MIME::Base64 0
       Net::SSLeay 0
       Test::More 0
-  Net-SSLeay-1.94
-    pathname: C/CH/CHRISN/Net-SSLeay-1.94.tar.gz
+  Net-SSLeay-1.96
+    pathname: C/CH/CHRISN/Net-SSLeay-1.96.tar.gz
     provides:
-      Net::SSLeay 1.94
-      Net::SSLeay::Handle 1.94
+      Net::SSLeay 1.96
+      Net::SSLeay::Handle 1.96
     requirements:
       English 0
       ExtUtils::MakeMaker 0
@@ -5489,6 +5507,19 @@ DISTRIBUTIONS
       Text::Wrap 0
       constant 0
       perl 5.008001
+  NetAddr-IP-4.079
+    pathname: M/MI/MIKER/NetAddr-IP-4.079.tar.gz
+    provides:
+      NetAddr::IP 4.079
+      NetAddr::IP::InetBase 0.08
+      NetAddr::IP::Lite 1.57
+      NetAddr::IP::Util 1.53
+      NetAddr::IP::UtilPP 1.09
+      NetAddr::IP::UtilPolluted 1.53
+      NetAddr::IP::Util_IS 1
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
   POSIX-strftime-Compiler-0.46
     pathname: K/KA/KAZEBURO/POSIX-strftime-Compiler-0.46.tar.gz
     provides:
@@ -5500,101 +5531,101 @@ DISTRIBUTIONS
       POSIX 0
       Time::Local 0
       perl 5.008001
-  PPI-1.284
-    pathname: O/OA/OALDERS/PPI-1.284.tar.gz
+  PPI-1.291
+    pathname: M/MI/MITHALDU/PPI-1.291.tar.gz
     provides:
-      PPI 1.284
-      PPI::Cache 1.284
-      PPI::Document 1.284
-      PPI::Document::File 1.284
-      PPI::Document::Fragment 1.284
-      PPI::Document::Normalized 1.284
-      PPI::Dumper 1.284
-      PPI::Element 1.284
-      PPI::Exception 1.284
-      PPI::Exception::ParserRejection 1.284
-      PPI::Find 1.284
-      PPI::Lexer 1.284
-      PPI::Node 1.284
-      PPI::Normal 1.284
-      PPI::Normal::Standard 1.284
-      PPI::Singletons 1.284
-      PPI::Statement 1.284
-      PPI::Statement::Break 1.284
-      PPI::Statement::Compound 1.284
-      PPI::Statement::Data 1.284
-      PPI::Statement::End 1.284
-      PPI::Statement::Expression 1.284
-      PPI::Statement::Given 1.284
-      PPI::Statement::Include 1.284
-      PPI::Statement::Include::Perl6 1.284
-      PPI::Statement::Null 1.284
-      PPI::Statement::Package 1.284
-      PPI::Statement::Scheduled 1.284
-      PPI::Statement::Sub 1.284
-      PPI::Statement::Unknown 1.284
-      PPI::Statement::UnmatchedBrace 1.284
-      PPI::Statement::Variable 1.284
-      PPI::Statement::When 1.284
-      PPI::Structure 1.284
-      PPI::Structure::Block 1.284
-      PPI::Structure::Condition 1.284
-      PPI::Structure::Constructor 1.284
-      PPI::Structure::For 1.284
-      PPI::Structure::Given 1.284
-      PPI::Structure::List 1.284
-      PPI::Structure::Signature 1.284
-      PPI::Structure::Subscript 1.284
-      PPI::Structure::Unknown 1.284
-      PPI::Structure::When 1.284
-      PPI::Token 1.284
-      PPI::Token::ArrayIndex 1.284
-      PPI::Token::Attribute 1.284
-      PPI::Token::BOM 1.284
-      PPI::Token::Cast 1.284
-      PPI::Token::Comment 1.284
-      PPI::Token::DashedWord 1.284
-      PPI::Token::Data 1.284
-      PPI::Token::End 1.284
-      PPI::Token::HereDoc 1.284
-      PPI::Token::Label 1.284
-      PPI::Token::Magic 1.284
-      PPI::Token::Number 1.284
-      PPI::Token::Number::Binary 1.284
-      PPI::Token::Number::Exp 1.284
-      PPI::Token::Number::Float 1.284
-      PPI::Token::Number::Hex 1.284
-      PPI::Token::Number::Octal 1.284
-      PPI::Token::Number::Version 1.284
-      PPI::Token::Operator 1.284
-      PPI::Token::Pod 1.284
-      PPI::Token::Prototype 1.284
-      PPI::Token::Quote 1.284
-      PPI::Token::Quote::Double 1.284
-      PPI::Token::Quote::Interpolate 1.284
-      PPI::Token::Quote::Literal 1.284
-      PPI::Token::Quote::Single 1.284
-      PPI::Token::QuoteLike 1.284
-      PPI::Token::QuoteLike::Backtick 1.284
-      PPI::Token::QuoteLike::Command 1.284
-      PPI::Token::QuoteLike::Readline 1.284
-      PPI::Token::QuoteLike::Regexp 1.284
-      PPI::Token::QuoteLike::Words 1.284
-      PPI::Token::Regexp 1.284
-      PPI::Token::Regexp::Match 1.284
-      PPI::Token::Regexp::Substitute 1.284
-      PPI::Token::Regexp::Transliterate 1.284
-      PPI::Token::Separator 1.284
-      PPI::Token::Structure 1.284
-      PPI::Token::Symbol 1.284
-      PPI::Token::Unknown 1.284
-      PPI::Token::Whitespace 1.284
-      PPI::Token::Word 1.284
-      PPI::Tokenizer 1.284
-      PPI::Transform 1.284
-      PPI::Transform::UpdateCopyright 1.284
-      PPI::Util 1.284
-      PPI::XSAccessor 1.284
+      PPI 1.291
+      PPI::Cache 1.291
+      PPI::Document 1.291
+      PPI::Document::File 1.291
+      PPI::Document::Fragment 1.291
+      PPI::Document::Normalized 1.291
+      PPI::Dumper 1.291
+      PPI::Element 1.291
+      PPI::Exception 1.291
+      PPI::Exception::ParserRejection 1.291
+      PPI::Find 1.291
+      PPI::Lexer 1.291
+      PPI::Node 1.291
+      PPI::Normal 1.291
+      PPI::Normal::Standard 1.291
+      PPI::Singletons 1.291
+      PPI::Statement 1.291
+      PPI::Statement::Break 1.291
+      PPI::Statement::Compound 1.291
+      PPI::Statement::Data 1.291
+      PPI::Statement::End 1.291
+      PPI::Statement::Expression 1.291
+      PPI::Statement::Given 1.291
+      PPI::Statement::Include 1.291
+      PPI::Statement::Include::Perl6 1.291
+      PPI::Statement::Null 1.291
+      PPI::Statement::Package 1.291
+      PPI::Statement::Scheduled 1.291
+      PPI::Statement::Sub 1.291
+      PPI::Statement::Unknown 1.291
+      PPI::Statement::UnmatchedBrace 1.291
+      PPI::Statement::Variable 1.291
+      PPI::Statement::When 1.291
+      PPI::Structure 1.291
+      PPI::Structure::Block 1.291
+      PPI::Structure::Condition 1.291
+      PPI::Structure::Constructor 1.291
+      PPI::Structure::For 1.291
+      PPI::Structure::Given 1.291
+      PPI::Structure::List 1.291
+      PPI::Structure::Signature 1.291
+      PPI::Structure::Subscript 1.291
+      PPI::Structure::Unknown 1.291
+      PPI::Structure::When 1.291
+      PPI::Token 1.291
+      PPI::Token::ArrayIndex 1.291
+      PPI::Token::Attribute 1.291
+      PPI::Token::BOM 1.291
+      PPI::Token::Cast 1.291
+      PPI::Token::Comment 1.291
+      PPI::Token::DashedWord 1.291
+      PPI::Token::Data 1.291
+      PPI::Token::End 1.291
+      PPI::Token::HereDoc 1.291
+      PPI::Token::Label 1.291
+      PPI::Token::Magic 1.291
+      PPI::Token::Number 1.291
+      PPI::Token::Number::Binary 1.291
+      PPI::Token::Number::Exp 1.291
+      PPI::Token::Number::Float 1.291
+      PPI::Token::Number::Hex 1.291
+      PPI::Token::Number::Octal 1.291
+      PPI::Token::Number::Version 1.291
+      PPI::Token::Operator 1.291
+      PPI::Token::Pod 1.291
+      PPI::Token::Prototype 1.291
+      PPI::Token::Quote 1.291
+      PPI::Token::Quote::Double 1.291
+      PPI::Token::Quote::Interpolate 1.291
+      PPI::Token::Quote::Literal 1.291
+      PPI::Token::Quote::Single 1.291
+      PPI::Token::QuoteLike 1.291
+      PPI::Token::QuoteLike::Backtick 1.291
+      PPI::Token::QuoteLike::Command 1.291
+      PPI::Token::QuoteLike::Readline 1.291
+      PPI::Token::QuoteLike::Regexp 1.291
+      PPI::Token::QuoteLike::Words 1.291
+      PPI::Token::Regexp 1.291
+      PPI::Token::Regexp::Match 1.291
+      PPI::Token::Regexp::Substitute 1.291
+      PPI::Token::Regexp::Transliterate 1.291
+      PPI::Token::Separator 1.291
+      PPI::Token::Structure 1.291
+      PPI::Token::Symbol 1.291
+      PPI::Token::Unknown 1.291
+      PPI::Token::Whitespace 1.291
+      PPI::Token::Word 1.291
+      PPI::Tokenizer 1.291
+      PPI::Transform 1.291
+      PPI::Transform::UpdateCopyright 1.291
+      PPI::Util 1.291
+      PPI::XSAccessor 1.291
     requirements:
       Carp 0
       Clone 0.30
@@ -5616,21 +5647,21 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       version 0.77
-  PPIx-QuoteLike-0.023
-    pathname: W/WY/WYANT/PPIx-QuoteLike-0.023.tar.gz
+  PPIx-QuoteLike-0.024
+    pathname: W/WY/WYANT/PPIx-QuoteLike-0.024.tar.gz
     provides:
-      PPIx::QuoteLike 0.023
-      PPIx::QuoteLike::Constant 0.023
-      PPIx::QuoteLike::Dumper 0.023
-      PPIx::QuoteLike::Token 0.023
-      PPIx::QuoteLike::Token::Control 0.023
-      PPIx::QuoteLike::Token::Delimiter 0.023
-      PPIx::QuoteLike::Token::Interpolation 0.023
-      PPIx::QuoteLike::Token::String 0.023
-      PPIx::QuoteLike::Token::Structure 0.023
-      PPIx::QuoteLike::Token::Unknown 0.023
-      PPIx::QuoteLike::Token::Whitespace 0.023
-      PPIx::QuoteLike::Utils 0.023
+      PPIx::QuoteLike 0.024
+      PPIx::QuoteLike::Constant 0.024
+      PPIx::QuoteLike::Dumper 0.024
+      PPIx::QuoteLike::Token 0.024
+      PPIx::QuoteLike::Token::Control 0.024
+      PPIx::QuoteLike::Token::Delimiter 0.024
+      PPIx::QuoteLike::Token::Interpolation 0.024
+      PPIx::QuoteLike::Token::String 0.024
+      PPIx::QuoteLike::Token::Structure 0.024
+      PPIx::QuoteLike::Token::Unknown 0.024
+      PPIx::QuoteLike::Token::Whitespace 0.024
+      PPIx::QuoteLike::Utils 0.024
     requirements:
       Carp 0
       Encode 0
@@ -5649,75 +5680,75 @@ DISTRIBUTIONS
       re 0
       strict 0
       warnings 0
-  PPIx-Regexp-0.091
-    pathname: W/WY/WYANT/PPIx-Regexp-0.091.tar.gz
+  PPIx-Regexp-0.092
+    pathname: W/WY/WYANT/PPIx-Regexp-0.092.tar.gz
     provides:
-      PPIx::Regexp 0.091
+      PPIx::Regexp 0.092
       PPIx::Regexp::Constant 0.085_04
-      PPIx::Regexp::Constant::Inf 0.091
-      PPIx::Regexp::Dumper 0.091
-      PPIx::Regexp::Element 0.091
-      PPIx::Regexp::Lexer 0.091
-      PPIx::Regexp::Node 0.091
-      PPIx::Regexp::Node::Range 0.091
-      PPIx::Regexp::Node::Unknown 0.091
-      PPIx::Regexp::Structure 0.091
-      PPIx::Regexp::Structure::Assertion 0.091
-      PPIx::Regexp::Structure::Atomic_Script_Run 0.091
-      PPIx::Regexp::Structure::BranchReset 0.091
-      PPIx::Regexp::Structure::Capture 0.091
-      PPIx::Regexp::Structure::CharClass 0.091
-      PPIx::Regexp::Structure::Code 0.091
-      PPIx::Regexp::Structure::Main 0.091
-      PPIx::Regexp::Structure::Modifier 0.091
-      PPIx::Regexp::Structure::NamedCapture 0.091
-      PPIx::Regexp::Structure::Quantifier 0.091
-      PPIx::Regexp::Structure::RegexSet 0.091
-      PPIx::Regexp::Structure::Regexp 0.091
-      PPIx::Regexp::Structure::Replacement 0.091
-      PPIx::Regexp::Structure::Script_Run 0.091
-      PPIx::Regexp::Structure::Subexpression 0.091
-      PPIx::Regexp::Structure::Switch 0.091
-      PPIx::Regexp::Structure::Unknown 0.091
-      PPIx::Regexp::Support 0.091
-      PPIx::Regexp::Token 0.091
-      PPIx::Regexp::Token::Assertion 0.091
-      PPIx::Regexp::Token::Backreference 0.091
-      PPIx::Regexp::Token::Backtrack 0.091
-      PPIx::Regexp::Token::CharClass 0.091
-      PPIx::Regexp::Token::CharClass::POSIX 0.091
-      PPIx::Regexp::Token::CharClass::POSIX::Unknown 0.091
-      PPIx::Regexp::Token::CharClass::Simple 0.091
-      PPIx::Regexp::Token::Code 0.091
-      PPIx::Regexp::Token::Comment 0.091
-      PPIx::Regexp::Token::Condition 0.091
-      PPIx::Regexp::Token::Control 0.091
-      PPIx::Regexp::Token::Delimiter 0.091
-      PPIx::Regexp::Token::Greediness 0.091
-      PPIx::Regexp::Token::GroupType 0.091
-      PPIx::Regexp::Token::GroupType::Assertion 0.091
-      PPIx::Regexp::Token::GroupType::Atomic_Script_Run 0.091
-      PPIx::Regexp::Token::GroupType::BranchReset 0.091
-      PPIx::Regexp::Token::GroupType::Code 0.091
-      PPIx::Regexp::Token::GroupType::Modifier 0.091
-      PPIx::Regexp::Token::GroupType::NamedCapture 0.091
-      PPIx::Regexp::Token::GroupType::Script_Run 0.091
-      PPIx::Regexp::Token::GroupType::Subexpression 0.091
-      PPIx::Regexp::Token::GroupType::Switch 0.091
-      PPIx::Regexp::Token::Interpolation 0.091
-      PPIx::Regexp::Token::Literal 0.091
-      PPIx::Regexp::Token::Modifier 0.091
-      PPIx::Regexp::Token::NoOp 0.091
-      PPIx::Regexp::Token::Operator 0.091
-      PPIx::Regexp::Token::Quantifier 0.091
-      PPIx::Regexp::Token::Recursion 0.091
-      PPIx::Regexp::Token::Reference 0.091
-      PPIx::Regexp::Token::Structure 0.091
-      PPIx::Regexp::Token::Unknown 0.091
-      PPIx::Regexp::Token::Unmatched 0.091
-      PPIx::Regexp::Token::Whitespace 0.091
-      PPIx::Regexp::Tokenizer 0.091
-      PPIx::Regexp::Util 0.091
+      PPIx::Regexp::Constant::Inf 0.092
+      PPIx::Regexp::Dumper 0.092
+      PPIx::Regexp::Element 0.092
+      PPIx::Regexp::Lexer 0.092
+      PPIx::Regexp::Node 0.092
+      PPIx::Regexp::Node::Range 0.092
+      PPIx::Regexp::Node::Unknown 0.092
+      PPIx::Regexp::Structure 0.092
+      PPIx::Regexp::Structure::Assertion 0.092
+      PPIx::Regexp::Structure::Atomic_Script_Run 0.092
+      PPIx::Regexp::Structure::BranchReset 0.092
+      PPIx::Regexp::Structure::Capture 0.092
+      PPIx::Regexp::Structure::CharClass 0.092
+      PPIx::Regexp::Structure::Code 0.092
+      PPIx::Regexp::Structure::Main 0.092
+      PPIx::Regexp::Structure::Modifier 0.092
+      PPIx::Regexp::Structure::NamedCapture 0.092
+      PPIx::Regexp::Structure::Quantifier 0.092
+      PPIx::Regexp::Structure::RegexSet 0.092
+      PPIx::Regexp::Structure::Regexp 0.092
+      PPIx::Regexp::Structure::Replacement 0.092
+      PPIx::Regexp::Structure::Script_Run 0.092
+      PPIx::Regexp::Structure::Subexpression 0.092
+      PPIx::Regexp::Structure::Switch 0.092
+      PPIx::Regexp::Structure::Unknown 0.092
+      PPIx::Regexp::Support 0.092
+      PPIx::Regexp::Token 0.092
+      PPIx::Regexp::Token::Assertion 0.092
+      PPIx::Regexp::Token::Backreference 0.092
+      PPIx::Regexp::Token::Backtrack 0.092
+      PPIx::Regexp::Token::CharClass 0.092
+      PPIx::Regexp::Token::CharClass::POSIX 0.092
+      PPIx::Regexp::Token::CharClass::POSIX::Unknown 0.092
+      PPIx::Regexp::Token::CharClass::Simple 0.092
+      PPIx::Regexp::Token::Code 0.092
+      PPIx::Regexp::Token::Comment 0.092
+      PPIx::Regexp::Token::Condition 0.092
+      PPIx::Regexp::Token::Control 0.092
+      PPIx::Regexp::Token::Delimiter 0.092
+      PPIx::Regexp::Token::Greediness 0.092
+      PPIx::Regexp::Token::GroupType 0.092
+      PPIx::Regexp::Token::GroupType::Assertion 0.092
+      PPIx::Regexp::Token::GroupType::Atomic_Script_Run 0.092
+      PPIx::Regexp::Token::GroupType::BranchReset 0.092
+      PPIx::Regexp::Token::GroupType::Code 0.092
+      PPIx::Regexp::Token::GroupType::Modifier 0.092
+      PPIx::Regexp::Token::GroupType::NamedCapture 0.092
+      PPIx::Regexp::Token::GroupType::Script_Run 0.092
+      PPIx::Regexp::Token::GroupType::Subexpression 0.092
+      PPIx::Regexp::Token::GroupType::Switch 0.092
+      PPIx::Regexp::Token::Interpolation 0.092
+      PPIx::Regexp::Token::Literal 0.092
+      PPIx::Regexp::Token::Modifier 0.092
+      PPIx::Regexp::Token::NoOp 0.092
+      PPIx::Regexp::Token::Operator 0.092
+      PPIx::Regexp::Token::Quantifier 0.092
+      PPIx::Regexp::Token::Recursion 0.092
+      PPIx::Regexp::Token::Reference 0.092
+      PPIx::Regexp::Token::Structure 0.092
+      PPIx::Regexp::Token::Unknown 0.092
+      PPIx::Regexp::Token::Unmatched 0.092
+      PPIx::Regexp::Token::Whitespace 0.092
+      PPIx::Regexp::Tokenizer 0.092
+      PPIx::Regexp::Util 0.092
     requirements:
       Carp 0
       Encode 0
@@ -5759,20 +5790,6 @@ DISTRIBUTIONS
       base 0
       strict 0
       warnings 0
-  PPIx-Utils-0.004
-    pathname: D/DB/DBOOK/PPIx-Utils-0.004.tar.gz
-    provides:
-      PPIx::Utils 0.004
-      PPIx::Utils::Classification 0.004
-      PPIx::Utils::Language 0.004
-      PPIx::Utils::Traversal 0.004
-    requirements:
-      B::Keywords 1.09
-      Exporter 0
-      ExtUtils::MakeMaker 0
-      PPI 1.250
-      Scalar::Util 0
-      perl 5.006
   Package-DeprecationManager-0.18
     pathname: D/DR/DROLSKY/Package-DeprecationManager-0.18.tar.gz
     provides:
@@ -5940,249 +5957,257 @@ DISTRIBUTIONS
       strict 0
       warnings 0
       warnings::register 0
-  Perl-Critic-1.156
-    pathname: P/PE/PETDANCE/Perl-Critic-1.156.tar.gz
+  Perl-Critic-1.132
+    pathname: P/PE/PETDANCE/Perl-Critic-1.132.tar.gz
     provides:
-      Perl::Critic 1.156
-      Perl::Critic::Annotation 1.156
-      Perl::Critic::Command 1.156
-      Perl::Critic::Config 1.156
-      Perl::Critic::Document 1.156
-      Perl::Critic::Exception 1.156
-      Perl::Critic::Exception::AggregateConfiguration 1.156
-      Perl::Critic::Exception::Configuration 1.156
-      Perl::Critic::Exception::Configuration::Generic 1.156
-      Perl::Critic::Exception::Configuration::NonExistentPolicy 1.156
-      Perl::Critic::Exception::Configuration::Option 1.156
-      Perl::Critic::Exception::Configuration::Option::Global 1.156
-      Perl::Critic::Exception::Configuration::Option::Global::ExtraParameter 1.156
-      Perl::Critic::Exception::Configuration::Option::Global::ParameterValue 1.156
-      Perl::Critic::Exception::Configuration::Option::Policy 1.156
-      Perl::Critic::Exception::Configuration::Option::Policy::ExtraParameter 1.156
-      Perl::Critic::Exception::Configuration::Option::Policy::ParameterValue 1.156
-      Perl::Critic::Exception::Fatal 1.156
-      Perl::Critic::Exception::Fatal::Generic 1.156
-      Perl::Critic::Exception::Fatal::Internal 1.156
-      Perl::Critic::Exception::Fatal::PolicyDefinition 1.156
-      Perl::Critic::Exception::IO 1.156
-      Perl::Critic::Exception::Parse 1.156
-      Perl::Critic::OptionsProcessor 1.156
-      Perl::Critic::Policy 1.156
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitBooleanGrep 1.156
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitComplexMappings 1.156
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitLvalueSubstr 1.156
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitReverseSortBlock 1.156
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitShiftRef 1.156
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitSleepViaSelect 1.156
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitStringyEval 1.156
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitStringySplit 1.156
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitUniversalCan 1.156
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitUniversalIsa 1.156
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitUselessTopic 1.156
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitVoidGrep 1.156
-      Perl::Critic::Policy::BuiltinFunctions::ProhibitVoidMap 1.156
-      Perl::Critic::Policy::BuiltinFunctions::RequireBlockGrep 1.156
-      Perl::Critic::Policy::BuiltinFunctions::RequireBlockMap 1.156
-      Perl::Critic::Policy::BuiltinFunctions::RequireGlobFunction 1.156
-      Perl::Critic::Policy::BuiltinFunctions::RequireSimpleSortBlock 1.156
-      Perl::Critic::Policy::ClassHierarchies::ProhibitAutoloading 1.156
-      Perl::Critic::Policy::ClassHierarchies::ProhibitExplicitISA 1.156
-      Perl::Critic::Policy::ClassHierarchies::ProhibitOneArgBless 1.156
-      Perl::Critic::Policy::CodeLayout::ProhibitHardTabs 1.156
-      Perl::Critic::Policy::CodeLayout::ProhibitParensWithBuiltins 1.156
-      Perl::Critic::Policy::CodeLayout::ProhibitQuotedWordLists 1.156
-      Perl::Critic::Policy::CodeLayout::ProhibitTrailingWhitespace 1.156
-      Perl::Critic::Policy::CodeLayout::RequireConsistentNewlines 1.156
-      Perl::Critic::Policy::CodeLayout::RequireTidyCode 1.156
-      Perl::Critic::Policy::CodeLayout::RequireTrailingCommas 1.156
-      Perl::Critic::Policy::ControlStructures::ProhibitCStyleForLoops 1.156
-      Perl::Critic::Policy::ControlStructures::ProhibitCascadingIfElse 1.156
-      Perl::Critic::Policy::ControlStructures::ProhibitDeepNests 1.156
-      Perl::Critic::Policy::ControlStructures::ProhibitLabelsWithSpecialBlockNames 1.156
-      Perl::Critic::Policy::ControlStructures::ProhibitMutatingListFunctions 1.156
-      Perl::Critic::Policy::ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions 1.156
-      Perl::Critic::Policy::ControlStructures::ProhibitPostfixControls 1.156
-      Perl::Critic::Policy::ControlStructures::ProhibitUnlessBlocks 1.156
-      Perl::Critic::Policy::ControlStructures::ProhibitUnreachableCode 1.156
-      Perl::Critic::Policy::ControlStructures::ProhibitUntilBlocks 1.156
-      Perl::Critic::Policy::ControlStructures::ProhibitYadaOperator 1.156
-      Perl::Critic::Policy::Documentation::PodSpelling 1.156
-      Perl::Critic::Policy::Documentation::RequirePackageMatchesPodName 1.156
-      Perl::Critic::Policy::Documentation::RequirePodAtEnd 1.156
-      Perl::Critic::Policy::Documentation::RequirePodSections 1.156
-      Perl::Critic::Policy::ErrorHandling::RequireCarping 1.156
-      Perl::Critic::Policy::ErrorHandling::RequireCheckingReturnValueOfEval 1.156
-      Perl::Critic::Policy::InputOutput::ProhibitBacktickOperators 1.156
-      Perl::Critic::Policy::InputOutput::ProhibitBarewordDirHandles 1.156
-      Perl::Critic::Policy::InputOutput::ProhibitBarewordFileHandles 1.156
-      Perl::Critic::Policy::InputOutput::ProhibitExplicitStdin 1.156
-      Perl::Critic::Policy::InputOutput::ProhibitInteractiveTest 1.156
-      Perl::Critic::Policy::InputOutput::ProhibitJoinedReadline 1.156
-      Perl::Critic::Policy::InputOutput::ProhibitOneArgSelect 1.156
-      Perl::Critic::Policy::InputOutput::ProhibitReadlineInForLoop 1.156
-      Perl::Critic::Policy::InputOutput::ProhibitTwoArgOpen 1.156
-      Perl::Critic::Policy::InputOutput::RequireBracedFileHandleWithPrint 1.156
-      Perl::Critic::Policy::InputOutput::RequireBriefOpen 1.156
-      Perl::Critic::Policy::InputOutput::RequireCheckedClose 1.156
-      Perl::Critic::Policy::InputOutput::RequireCheckedOpen 1.156
-      Perl::Critic::Policy::InputOutput::RequireCheckedSyscalls 1.156
-      Perl::Critic::Policy::InputOutput::RequireEncodingWithUTF8Layer 1.156
-      Perl::Critic::Policy::Miscellanea::ProhibitFormats 1.156
-      Perl::Critic::Policy::Miscellanea::ProhibitTies 1.156
-      Perl::Critic::Policy::Miscellanea::ProhibitUnrestrictedNoCritic 1.156
-      Perl::Critic::Policy::Miscellanea::ProhibitUselessNoCritic 1.156
-      Perl::Critic::Policy::Modules::ProhibitAutomaticExportation 1.156
-      Perl::Critic::Policy::Modules::ProhibitConditionalUseStatements 1.156
-      Perl::Critic::Policy::Modules::ProhibitEvilModules 1.156
-      Perl::Critic::Policy::Modules::ProhibitExcessMainComplexity 1.156
-      Perl::Critic::Policy::Modules::ProhibitMultiplePackages 1.156
-      Perl::Critic::Policy::Modules::RequireBarewordIncludes 1.156
-      Perl::Critic::Policy::Modules::RequireEndWithOne 1.156
-      Perl::Critic::Policy::Modules::RequireExplicitPackage 1.156
-      Perl::Critic::Policy::Modules::RequireFilenameMatchesPackage 1.156
-      Perl::Critic::Policy::Modules::RequireNoMatchVarsWithUseEnglish 1.156
-      Perl::Critic::Policy::Modules::RequireVersionVar 1.156
-      Perl::Critic::Policy::NamingConventions::Capitalization 1.156
-      Perl::Critic::Policy::NamingConventions::ProhibitAmbiguousNames 1.156
-      Perl::Critic::Policy::Objects::ProhibitIndirectSyntax 1.156
-      Perl::Critic::Policy::References::ProhibitDoubleSigils 1.156
-      Perl::Critic::Policy::RegularExpressions::ProhibitCaptureWithoutTest 1.156
-      Perl::Critic::Policy::RegularExpressions::ProhibitComplexRegexes 1.156
-      Perl::Critic::Policy::RegularExpressions::ProhibitEnumeratedClasses 1.156
-      Perl::Critic::Policy::RegularExpressions::ProhibitEscapedMetacharacters 1.156
-      Perl::Critic::Policy::RegularExpressions::ProhibitFixedStringMatches 1.156
-      Perl::Critic::Policy::RegularExpressions::ProhibitSingleCharAlternation 1.156
-      Perl::Critic::Policy::RegularExpressions::ProhibitUnusedCapture 1.156
-      Perl::Critic::Policy::RegularExpressions::ProhibitUnusualDelimiters 1.156
-      Perl::Critic::Policy::RegularExpressions::ProhibitUselessTopic 1.156
-      Perl::Critic::Policy::RegularExpressions::RequireBracesForMultiline 1.156
-      Perl::Critic::Policy::RegularExpressions::RequireDotMatchAnything 1.156
-      Perl::Critic::Policy::RegularExpressions::RequireExtendedFormatting 1.156
-      Perl::Critic::Policy::RegularExpressions::RequireLineBoundaryMatching 1.156
-      Perl::Critic::Policy::Subroutines::ProhibitAmpersandSigils 1.156
-      Perl::Critic::Policy::Subroutines::ProhibitBuiltinHomonyms 1.156
-      Perl::Critic::Policy::Subroutines::ProhibitExcessComplexity 1.156
-      Perl::Critic::Policy::Subroutines::ProhibitExplicitReturnUndef 1.156
-      Perl::Critic::Policy::Subroutines::ProhibitManyArgs 1.156
-      Perl::Critic::Policy::Subroutines::ProhibitNestedSubs 1.156
-      Perl::Critic::Policy::Subroutines::ProhibitReturnSort 1.156
-      Perl::Critic::Policy::Subroutines::ProhibitSubroutinePrototypes 1.156
-      Perl::Critic::Policy::Subroutines::ProhibitUnusedPrivateSubroutines 1.156
-      Perl::Critic::Policy::Subroutines::ProtectPrivateSubs 1.156
-      Perl::Critic::Policy::Subroutines::RequireArgUnpacking 1.156
-      Perl::Critic::Policy::Subroutines::RequireFinalReturn 1.156
-      Perl::Critic::Policy::TestingAndDebugging::ProhibitNoStrict 1.156
-      Perl::Critic::Policy::TestingAndDebugging::ProhibitNoWarnings 1.156
-      Perl::Critic::Policy::TestingAndDebugging::ProhibitProlongedStrictureOverride 1.156
-      Perl::Critic::Policy::TestingAndDebugging::RequireTestLabels 1.156
-      Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict 1.156
-      Perl::Critic::Policy::TestingAndDebugging::RequireUseWarnings 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitCommaSeparatedStatements 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitComplexVersion 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitConstantPragma 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitEmptyQuotes 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitEscapedCharacters 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitImplicitNewlines 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitInterpolationOfLiterals 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitLeadingZeros 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitLongChainsOfMethodCalls 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitMagicNumbers 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitMismatchedOperators 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitMixedBooleanOperators 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitNoisyQuotes 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitQuotesAsQuotelikeOperatorDelimiters 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitSpecialLiteralHeredocTerminator 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::ProhibitVersionStrings 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::RequireConstantVersion 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::RequireInterpolationOfMetachars 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::RequireNumberSeparators 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::RequireQuotedHeredocTerminator 1.156
-      Perl::Critic::Policy::ValuesAndExpressions::RequireUpperCaseHeredocTerminator 1.156
-      Perl::Critic::Policy::Variables::ProhibitAugmentedAssignmentInDeclaration 1.156
-      Perl::Critic::Policy::Variables::ProhibitConditionalDeclarations 1.156
-      Perl::Critic::Policy::Variables::ProhibitEvilVariables 1.156
-      Perl::Critic::Policy::Variables::ProhibitLocalVars 1.156
-      Perl::Critic::Policy::Variables::ProhibitMatchVars 1.156
-      Perl::Critic::Policy::Variables::ProhibitPackageVars 1.156
-      Perl::Critic::Policy::Variables::ProhibitPerl4PackageNames 1.156
-      Perl::Critic::Policy::Variables::ProhibitPunctuationVars 1.156
-      Perl::Critic::Policy::Variables::ProhibitReusedNames 1.156
-      Perl::Critic::Policy::Variables::ProhibitUnusedVariables 1.156
-      Perl::Critic::Policy::Variables::ProtectPrivateVars 1.156
-      Perl::Critic::Policy::Variables::RequireInitializationForLocalVars 1.156
-      Perl::Critic::Policy::Variables::RequireLexicalLoopIterators 1.156
-      Perl::Critic::Policy::Variables::RequireLocalizedPunctuationVars 1.156
-      Perl::Critic::Policy::Variables::RequireNegativeIndices 1.156
-      Perl::Critic::PolicyConfig 1.156
-      Perl::Critic::PolicyFactory 1.156
-      Perl::Critic::PolicyListing 1.156
-      Perl::Critic::PolicyParameter 1.156
-      Perl::Critic::PolicyParameter::Behavior 1.156
-      Perl::Critic::PolicyParameter::Behavior::Boolean 1.156
-      Perl::Critic::PolicyParameter::Behavior::Enumeration 1.156
-      Perl::Critic::PolicyParameter::Behavior::Integer 1.156
-      Perl::Critic::PolicyParameter::Behavior::String 1.156
-      Perl::Critic::PolicyParameter::Behavior::StringList 1.156
-      Perl::Critic::ProfilePrototype 1.156
-      Perl::Critic::Statistics 1.156
-      Perl::Critic::TestUtils 1.156
-      Perl::Critic::Theme 1.156
-      Perl::Critic::ThemeListing 1.156
-      Perl::Critic::UserProfile 1.156
-      Perl::Critic::Utils 1.156
-      Perl::Critic::Utils::Constants 1.156
-      Perl::Critic::Utils::McCabe 1.156
-      Perl::Critic::Utils::POD 1.156
-      Perl::Critic::Utils::PPI 1.156
-      Perl::Critic::Utils::Perl 1.156
-      Perl::Critic::Violation 1.156
-      Test::Perl::Critic::Policy 1.156
+      Perl::Critic 1.132
+      Perl::Critic::Annotation 1.132
+      Perl::Critic::Command 1.132
+      Perl::Critic::Config 1.132
+      Perl::Critic::Document 1.132
+      Perl::Critic::Exception 1.132
+      Perl::Critic::Exception::AggregateConfiguration 1.132
+      Perl::Critic::Exception::Configuration 1.132
+      Perl::Critic::Exception::Configuration::Generic 1.132
+      Perl::Critic::Exception::Configuration::NonExistentPolicy 1.132
+      Perl::Critic::Exception::Configuration::Option 1.132
+      Perl::Critic::Exception::Configuration::Option::Global 1.132
+      Perl::Critic::Exception::Configuration::Option::Global::ExtraParameter 1.132
+      Perl::Critic::Exception::Configuration::Option::Global::ParameterValue 1.132
+      Perl::Critic::Exception::Configuration::Option::Policy 1.132
+      Perl::Critic::Exception::Configuration::Option::Policy::ExtraParameter 1.132
+      Perl::Critic::Exception::Configuration::Option::Policy::ParameterValue 1.132
+      Perl::Critic::Exception::Fatal 1.132
+      Perl::Critic::Exception::Fatal::Generic 1.132
+      Perl::Critic::Exception::Fatal::Internal 1.132
+      Perl::Critic::Exception::Fatal::PolicyDefinition 1.132
+      Perl::Critic::Exception::IO 1.132
+      Perl::Critic::Exception::Parse 1.132
+      Perl::Critic::OptionsProcessor 1.132
+      Perl::Critic::Policy 1.132
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitBooleanGrep 1.132
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitComplexMappings 1.132
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitLvalueSubstr 1.132
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitReverseSortBlock 1.132
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitSleepViaSelect 1.132
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitStringyEval 1.132
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitStringySplit 1.132
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitUniversalCan 1.132
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitUniversalIsa 1.132
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitUselessTopic 1.132
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitVoidGrep 1.132
+      Perl::Critic::Policy::BuiltinFunctions::ProhibitVoidMap 1.132
+      Perl::Critic::Policy::BuiltinFunctions::RequireBlockGrep 1.132
+      Perl::Critic::Policy::BuiltinFunctions::RequireBlockMap 1.132
+      Perl::Critic::Policy::BuiltinFunctions::RequireGlobFunction 1.132
+      Perl::Critic::Policy::BuiltinFunctions::RequireSimpleSortBlock 1.132
+      Perl::Critic::Policy::ClassHierarchies::ProhibitAutoloading 1.132
+      Perl::Critic::Policy::ClassHierarchies::ProhibitExplicitISA 1.132
+      Perl::Critic::Policy::ClassHierarchies::ProhibitOneArgBless 1.132
+      Perl::Critic::Policy::CodeLayout::ProhibitHardTabs 1.132
+      Perl::Critic::Policy::CodeLayout::ProhibitParensWithBuiltins 1.132
+      Perl::Critic::Policy::CodeLayout::ProhibitQuotedWordLists 1.132
+      Perl::Critic::Policy::CodeLayout::ProhibitTrailingWhitespace 1.132
+      Perl::Critic::Policy::CodeLayout::RequireConsistentNewlines 1.132
+      Perl::Critic::Policy::CodeLayout::RequireTidyCode 1.132
+      Perl::Critic::Policy::CodeLayout::RequireTrailingCommas 1.132
+      Perl::Critic::Policy::ControlStructures::ProhibitCStyleForLoops 1.132
+      Perl::Critic::Policy::ControlStructures::ProhibitCascadingIfElse 1.132
+      Perl::Critic::Policy::ControlStructures::ProhibitDeepNests 1.132
+      Perl::Critic::Policy::ControlStructures::ProhibitLabelsWithSpecialBlockNames 1.132
+      Perl::Critic::Policy::ControlStructures::ProhibitMutatingListFunctions 1.132
+      Perl::Critic::Policy::ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions 1.132
+      Perl::Critic::Policy::ControlStructures::ProhibitPostfixControls 1.132
+      Perl::Critic::Policy::ControlStructures::ProhibitUnlessBlocks 1.132
+      Perl::Critic::Policy::ControlStructures::ProhibitUnreachableCode 1.132
+      Perl::Critic::Policy::ControlStructures::ProhibitUntilBlocks 1.132
+      Perl::Critic::Policy::ControlStructures::ProhibitYadaOperator 1.132
+      Perl::Critic::Policy::Documentation::PodSpelling 1.132
+      Perl::Critic::Policy::Documentation::RequirePackageMatchesPodName 1.132
+      Perl::Critic::Policy::Documentation::RequirePodAtEnd 1.132
+      Perl::Critic::Policy::Documentation::RequirePodLinksIncludeText 1.132
+      Perl::Critic::Policy::Documentation::RequirePodSections 1.132
+      Perl::Critic::Policy::ErrorHandling::RequireCarping 1.132
+      Perl::Critic::Policy::ErrorHandling::RequireCheckingReturnValueOfEval 1.132
+      Perl::Critic::Policy::InputOutput::ProhibitBacktickOperators 1.132
+      Perl::Critic::Policy::InputOutput::ProhibitBarewordFileHandles 1.132
+      Perl::Critic::Policy::InputOutput::ProhibitExplicitStdin 1.132
+      Perl::Critic::Policy::InputOutput::ProhibitInteractiveTest 1.132
+      Perl::Critic::Policy::InputOutput::ProhibitJoinedReadline 1.132
+      Perl::Critic::Policy::InputOutput::ProhibitOneArgSelect 1.132
+      Perl::Critic::Policy::InputOutput::ProhibitReadlineInForLoop 1.132
+      Perl::Critic::Policy::InputOutput::ProhibitTwoArgOpen 1.132
+      Perl::Critic::Policy::InputOutput::RequireBracedFileHandleWithPrint 1.132
+      Perl::Critic::Policy::InputOutput::RequireBriefOpen 1.132
+      Perl::Critic::Policy::InputOutput::RequireCheckedClose 1.132
+      Perl::Critic::Policy::InputOutput::RequireCheckedOpen 1.132
+      Perl::Critic::Policy::InputOutput::RequireCheckedSyscalls 1.132
+      Perl::Critic::Policy::InputOutput::RequireEncodingWithUTF8Layer 1.132
+      Perl::Critic::Policy::Miscellanea::ProhibitFormats 1.132
+      Perl::Critic::Policy::Miscellanea::ProhibitTies 1.132
+      Perl::Critic::Policy::Miscellanea::ProhibitUnrestrictedNoCritic 1.132
+      Perl::Critic::Policy::Miscellanea::ProhibitUselessNoCritic 1.132
+      Perl::Critic::Policy::Modules::ProhibitAutomaticExportation 1.132
+      Perl::Critic::Policy::Modules::ProhibitConditionalUseStatements 1.132
+      Perl::Critic::Policy::Modules::ProhibitEvilModules 1.132
+      Perl::Critic::Policy::Modules::ProhibitExcessMainComplexity 1.132
+      Perl::Critic::Policy::Modules::ProhibitMultiplePackages 1.132
+      Perl::Critic::Policy::Modules::RequireBarewordIncludes 1.132
+      Perl::Critic::Policy::Modules::RequireEndWithOne 1.132
+      Perl::Critic::Policy::Modules::RequireExplicitPackage 1.132
+      Perl::Critic::Policy::Modules::RequireFilenameMatchesPackage 1.132
+      Perl::Critic::Policy::Modules::RequireNoMatchVarsWithUseEnglish 1.132
+      Perl::Critic::Policy::Modules::RequireVersionVar 1.132
+      Perl::Critic::Policy::NamingConventions::Capitalization 1.132
+      Perl::Critic::Policy::NamingConventions::ProhibitAmbiguousNames 1.132
+      Perl::Critic::Policy::Objects::ProhibitIndirectSyntax 1.132
+      Perl::Critic::Policy::References::ProhibitDoubleSigils 1.132
+      Perl::Critic::Policy::RegularExpressions::ProhibitCaptureWithoutTest 1.132
+      Perl::Critic::Policy::RegularExpressions::ProhibitComplexRegexes 1.132
+      Perl::Critic::Policy::RegularExpressions::ProhibitEnumeratedClasses 1.132
+      Perl::Critic::Policy::RegularExpressions::ProhibitEscapedMetacharacters 1.132
+      Perl::Critic::Policy::RegularExpressions::ProhibitFixedStringMatches 1.132
+      Perl::Critic::Policy::RegularExpressions::ProhibitSingleCharAlternation 1.132
+      Perl::Critic::Policy::RegularExpressions::ProhibitUnusedCapture 1.132
+      Perl::Critic::Policy::RegularExpressions::ProhibitUnusualDelimiters 1.132
+      Perl::Critic::Policy::RegularExpressions::ProhibitUselessTopic 1.132
+      Perl::Critic::Policy::RegularExpressions::RequireBracesForMultiline 1.132
+      Perl::Critic::Policy::RegularExpressions::RequireDotMatchAnything 1.132
+      Perl::Critic::Policy::RegularExpressions::RequireExtendedFormatting 1.132
+      Perl::Critic::Policy::RegularExpressions::RequireLineBoundaryMatching 1.132
+      Perl::Critic::Policy::Subroutines::ProhibitAmpersandSigils 1.132
+      Perl::Critic::Policy::Subroutines::ProhibitBuiltinHomonyms 1.132
+      Perl::Critic::Policy::Subroutines::ProhibitExcessComplexity 1.132
+      Perl::Critic::Policy::Subroutines::ProhibitExplicitReturnUndef 1.132
+      Perl::Critic::Policy::Subroutines::ProhibitManyArgs 1.132
+      Perl::Critic::Policy::Subroutines::ProhibitNestedSubs 1.132
+      Perl::Critic::Policy::Subroutines::ProhibitReturnSort 1.132
+      Perl::Critic::Policy::Subroutines::ProhibitSubroutinePrototypes 1.132
+      Perl::Critic::Policy::Subroutines::ProhibitUnusedPrivateSubroutines 1.132
+      Perl::Critic::Policy::Subroutines::ProtectPrivateSubs 1.132
+      Perl::Critic::Policy::Subroutines::RequireArgUnpacking 1.132
+      Perl::Critic::Policy::Subroutines::RequireFinalReturn 1.132
+      Perl::Critic::Policy::TestingAndDebugging::ProhibitNoStrict 1.132
+      Perl::Critic::Policy::TestingAndDebugging::ProhibitNoWarnings 1.132
+      Perl::Critic::Policy::TestingAndDebugging::ProhibitProlongedStrictureOverride 1.132
+      Perl::Critic::Policy::TestingAndDebugging::RequireTestLabels 1.132
+      Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict 1.132
+      Perl::Critic::Policy::TestingAndDebugging::RequireUseWarnings 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitCommaSeparatedStatements 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitComplexVersion 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitConstantPragma 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitEmptyQuotes 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitEscapedCharacters 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitImplicitNewlines 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitInterpolationOfLiterals 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitLeadingZeros 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitLongChainsOfMethodCalls 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitMagicNumbers 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitMismatchedOperators 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitMixedBooleanOperators 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitNoisyQuotes 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitQuotesAsQuotelikeOperatorDelimiters 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitSpecialLiteralHeredocTerminator 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::ProhibitVersionStrings 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::RequireConstantVersion 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::RequireInterpolationOfMetachars 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::RequireNumberSeparators 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::RequireQuotedHeredocTerminator 1.132
+      Perl::Critic::Policy::ValuesAndExpressions::RequireUpperCaseHeredocTerminator 1.132
+      Perl::Critic::Policy::Variables::ProhibitAugmentedAssignmentInDeclaration 1.132
+      Perl::Critic::Policy::Variables::ProhibitConditionalDeclarations 1.132
+      Perl::Critic::Policy::Variables::ProhibitEvilVariables 1.132
+      Perl::Critic::Policy::Variables::ProhibitLocalVars 1.132
+      Perl::Critic::Policy::Variables::ProhibitMatchVars 1.132
+      Perl::Critic::Policy::Variables::ProhibitPackageVars 1.132
+      Perl::Critic::Policy::Variables::ProhibitPerl4PackageNames 1.132
+      Perl::Critic::Policy::Variables::ProhibitPunctuationVars 1.132
+      Perl::Critic::Policy::Variables::ProhibitReusedNames 1.132
+      Perl::Critic::Policy::Variables::ProhibitUnusedVariables 1.132
+      Perl::Critic::Policy::Variables::ProtectPrivateVars 1.132
+      Perl::Critic::Policy::Variables::RequireInitializationForLocalVars 1.132
+      Perl::Critic::Policy::Variables::RequireLexicalLoopIterators 1.132
+      Perl::Critic::Policy::Variables::RequireLocalizedPunctuationVars 1.132
+      Perl::Critic::Policy::Variables::RequireNegativeIndices 1.132
+      Perl::Critic::PolicyConfig 1.132
+      Perl::Critic::PolicyFactory 1.132
+      Perl::Critic::PolicyListing 1.132
+      Perl::Critic::PolicyParameter 1.132
+      Perl::Critic::PolicyParameter::Behavior 1.132
+      Perl::Critic::PolicyParameter::Behavior::Boolean 1.132
+      Perl::Critic::PolicyParameter::Behavior::Enumeration 1.132
+      Perl::Critic::PolicyParameter::Behavior::Integer 1.132
+      Perl::Critic::PolicyParameter::Behavior::String 1.132
+      Perl::Critic::PolicyParameter::Behavior::StringList 1.132
+      Perl::Critic::ProfilePrototype 1.132
+      Perl::Critic::Statistics 1.132
+      Perl::Critic::TestUtils 1.132
+      Perl::Critic::Theme 1.132
+      Perl::Critic::ThemeListing 1.132
+      Perl::Critic::UserProfile 1.132
+      Perl::Critic::Utils 1.132
+      Perl::Critic::Utils::Constants 1.132
+      Perl::Critic::Utils::DataConversion 1.132
+      Perl::Critic::Utils::McCabe 1.132
+      Perl::Critic::Utils::POD 1.132
+      Perl::Critic::Utils::POD::ParseInteriorSequence 1.132
+      Perl::Critic::Utils::PPI 1.132
+      Perl::Critic::Utils::Perl 1.132
+      Perl::Critic::Violation 1.132
+      Test::Perl::Critic::Policy 1.132
     requirements:
-      B::Keywords 1.23
+      B::Keywords 1.05
       Carp 0
       Config::Tiny 2
       English 0
       Exception::Class 1.23
       Exporter 5.63
+      Fatal 0
       File::Basename 0
       File::Find 0
+      File::HomeDir 0
       File::Path 0
       File::Spec 0
       File::Spec::Unix 0
       File::Temp 0
       File::Which 0
       Getopt::Long 0
-      List::SomeUtils 0.55
+      IO::String 0
+      IPC::Open2 1
+      List::MoreUtils 0.19
       List::Util 0
-      Module::Build 0.4204
+      Module::Build 0.4024
       Module::Pluggable 3.1
-      PPI 1.277
-      PPI::Document 1.277
-      PPI::Document::File 1.277
-      PPI::Node 1.277
-      PPI::Token::Quote::Single 1.277
-      PPI::Token::Whitespace 1.277
+      PPI 1.224
+      PPI::Document 1.224
+      PPI::Document::File 1.224
+      PPI::Node 1.224
+      PPI::Token::Quote::Single 1.224
+      PPI::Token::Whitespace 1.224
       PPIx::QuoteLike 0
       PPIx::Regexp 0.027
-      PPIx::Regexp::Util 0.068
-      PPIx::Utils::Traversal 0.003
+      PPIx::Utilities::Node 1.001
+      PPIx::Utilities::Statement 1.001
       Perl::Tidy 0
+      Pod::Parser 0
       Pod::PlainText 0
       Pod::Select 0
       Pod::Spell 1
       Pod::Usage 0
       Readonly 2
       Scalar::Util 0
-      String::Format 1.18
+      String::Format 1.13
+      Task::Weaken 0
       Term::ANSIColor 2.02
       Test::Builder 0.92
+      Test::Deep 0
+      Test::More 0
       Text::ParseWords 3
       base 0
       charnames 0
       lib 0
       overload 0
-      parent 0
-      perl 5.010001
+      perl 5.006001
       strict 0
       version 0.77
       warnings 0
@@ -6283,33 +6308,33 @@ DISTRIBUTIONS
       Perl::Critic::Policy 0
       Perl::Critic::Utils 0
       perl 5.006
-  Perl-Critic-Policy-Variables-ProhibitLoopOnHash-0.008
-    pathname: X/XS/XSAWYERX/Perl-Critic-Policy-Variables-ProhibitLoopOnHash-0.008.tar.gz
+  Perl-Critic-Policy-Variables-ProhibitLoopOnHash-0.009
+    pathname: X/XS/XSAWYERX/Perl-Critic-Policy-Variables-ProhibitLoopOnHash-0.009.tar.gz
     provides:
-      Perl::Critic::Policy::Variables::ProhibitLoopOnHash 0.008
+      Perl::Critic::Policy::Variables::ProhibitLoopOnHash 0.009
     requirements:
       Carp 0
       ExtUtils::MakeMaker 0
       List::Util 1.33
       Perl::Critic 1.126
       parent 0
-  Perl-Tidy-20250912
-    pathname: S/SH/SHANCOCK/Perl-Tidy-20250912.tar.gz
+  Perl-Tidy-20260705
+    pathname: S/SH/SHANCOCK/Perl-Tidy-20260705.tar.gz
     provides:
-      Perl::Tidy 20250912
-      Perl::Tidy::Debugger 20250912
-      Perl::Tidy::Diagnostics 20250912
-      Perl::Tidy::FileWriter 20250912
-      Perl::Tidy::Formatter 20250912
-      Perl::Tidy::HtmlWriter 20250912
-      Perl::Tidy::IOScalar 20250912
-      Perl::Tidy::IOScalarArray 20250912
-      Perl::Tidy::IndentationItem 20250912
-      Perl::Tidy::Logger 20250912
-      Perl::Tidy::Tokenizer 20250912
-      Perl::Tidy::VerticalAligner 20250912
-      Perl::Tidy::VerticalAligner::Alignment 20250912
-      Perl::Tidy::VerticalAligner::Line 20250912
+      Perl::Tidy 20260705
+      Perl::Tidy::Debugger 20260705
+      Perl::Tidy::Diagnostics 20260705
+      Perl::Tidy::FileWriter 20260705
+      Perl::Tidy::Formatter 20260705
+      Perl::Tidy::HtmlWriter 20260705
+      Perl::Tidy::IOScalar 20260705
+      Perl::Tidy::IOScalarArray 20260705
+      Perl::Tidy::IndentationItem 20260705
+      Perl::Tidy::Logger 20260705
+      Perl::Tidy::Tokenizer 20260705
+      Perl::Tidy::VerticalAligner 20260705
+      Perl::Tidy::VerticalAligner::Alignment 20260705
+      Perl::Tidy::VerticalAligner::Line 20260705
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.008001
@@ -6332,12 +6357,12 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 6.17
       Scalar::Util 0
       perl 5.006
-  Plack-1.0051
-    pathname: M/MI/MIYAGAWA/Plack-1.0051.tar.gz
+  Plack-1.0054
+    pathname: M/MI/MIYAGAWA/Plack-1.0054.tar.gz
     provides:
       HTTP::Message::PSGI undef
       HTTP::Server::PSGI undef
-      Plack 1.0051
+      Plack 1.0054
       Plack::App::CGIBin undef
       Plack::App::Cascade undef
       Plack::App::Directory undef
@@ -6396,9 +6421,9 @@ DISTRIBUTIONS
       Plack::Middleware::XFramework undef
       Plack::Middleware::XSendfile undef
       Plack::Recursive::ForwardRequest undef
-      Plack::Request 1.0051
+      Plack::Request 1.0054
       Plack::Request::Upload undef
-      Plack::Response 1.0051
+      Plack::Response 1.0054
       Plack::Runner undef
       Plack::TempBuffer undef
       Plack::Test undef
@@ -6566,13 +6591,13 @@ DISTRIBUTIONS
       strict 0
       vars 0
       warnings 0
-  Role-Tiny-2.002004
-    pathname: H/HA/HAARG/Role-Tiny-2.002004.tar.gz
+  Role-Tiny-2.002005
+    pathname: H/HA/HAARG/Role-Tiny-2.002005.tar.gz
     provides:
-      Role::Tiny 2.002004
-      Role::Tiny::With 2.002004
+      Role::Tiny 2.002005
+      Role::Tiny::With 2.002005
     requirements:
-      Exporter 5.57
+      Exporter 0
       perl 5.006
   Router-Simple-0.17
     pathname: T/TO/TOKUHIROM/Router-Simple-0.17.tar.gz
@@ -6847,58 +6872,37 @@ DISTRIBUTIONS
       URI 0
       UUID::Tiny 0
       perl 5.008
-  Sereal-5.004
-    pathname: Y/YV/YVES/Sereal-5.004.tar.gz
+  Sereal-5.009
+    pathname: Y/YV/YVES/Sereal-5.009.tar.gz
     provides:
-      Sereal 5.004
+      Sereal 5.009
     requirements:
       ExtUtils::MakeMaker 0
-      Sereal::Decoder 5.004
-      Sereal::Encoder 5.004
+      Sereal::Decoder 5.009
+      Sereal::Encoder 5.009
       perl 5.008
-  Sereal-Decoder-5.004
-    pathname: Y/YV/YVES/Sereal-Decoder-5.004.tar.gz
+  Sereal-Decoder-5.009
+    pathname: Y/YV/YVES/Sereal-Decoder-5.009.tar.gz
     provides:
-      Sereal::Decoder 5.004
-      Sereal::Decoder::Constants 5.004
+      Sereal::Decoder 5.009
+      Sereal::Decoder::Constants 5.009
       Sereal::Performance undef
     requirements:
-      Data::Dumper 0
       Devel::CheckLib 1.16
       ExtUtils::MakeMaker 7.0
       ExtUtils::ParseXS 2.21
-      File::Find 0
-      File::Path 0
-      File::Spec 0
-      Scalar::Util 0
-      Test::Deep 0
-      Test::Differences 0
-      Test::LongString 0
-      Test::More 0.88
-      Test::Warn 0
       XSLoader 0
       perl 5.008
-  Sereal-Encoder-5.004
-    pathname: Y/YV/YVES/Sereal-Encoder-5.004.tar.gz
+  Sereal-Encoder-5.009
+    pathname: Y/YV/YVES/Sereal-Encoder-5.009.tar.gz
     provides:
-      Sereal::Encoder 5.004
-      Sereal::Encoder::Constants 5.004
+      Sereal::Encoder 5.009
+      Sereal::Encoder::Constants 5.009
     requirements:
-      Data::Dumper 0
       Devel::CheckLib 1.16
       ExtUtils::MakeMaker 7.0
       ExtUtils::ParseXS 2.21
-      File::Find 0
-      File::Path 0
-      File::Spec 0
-      Hash::Util 0
-      Scalar::Util 0
-      Sereal::Decoder 5.004
-      Test::Deep 0
-      Test::Differences 0
-      Test::LongString 0
-      Test::More 0.88
-      Test::Warn 0
+      Sereal::Decoder 5.009
       XSLoader 0
       perl 5.008
   Set-Infinite-0.65
@@ -7159,66 +7163,68 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       GD 1.14
       Template 2.14
-  Template-Toolkit-3.102
-    pathname: T/TO/TODDR/Template-Toolkit-3.102.tar.gz
+  Template-Toolkit-3.106
+    pathname: T/TO/TODDR/Template-Toolkit-3.106.tar.gz
     provides:
-      Template 3.102
-      Template::App::ttree 2.91
-      Template::Base 3.100
-      Template::Config 3.100
-      Template::Constants 3.100
-      Template::Context 3.100
-      Template::Directive 3.100
-      Template::Document 3.100
-      Template::Exception 3.100
-      Template::Filters 3.100
-      Template::Grammar 3.100
-      Template::Iterator 3.100
-      Template::Monad::Assert 3.100
-      Template::Monad::Scalar 3.100
-      Template::Namespace::Constants 3.100
-      Template::Parser 3.100
-      Template::Perl 3.100
-      Template::Plugin 3.100
-      Template::Plugin::Assert 3.100
-      Template::Plugin::Datafile 3.100
-      Template::Plugin::Date 3.100
-      Template::Plugin::Date::Calc 3.100
-      Template::Plugin::Date::Manip 3.100
-      Template::Plugin::Directory 3.100
-      Template::Plugin::Dumper 3.100
-      Template::Plugin::File 3.100
-      Template::Plugin::Filter 3.100
-      Template::Plugin::Format 3.100
-      Template::Plugin::HTML 3.100
-      Template::Plugin::Image 3.100
-      Template::Plugin::Iterator 3.100
-      Template::Plugin::Math 3.100
-      Template::Plugin::Pod 3.100
-      Template::Plugin::Procedural 3.100
-      Template::Plugin::Scalar 3.100
-      Template::Plugin::String 3.100
-      Template::Plugin::Table 3.100
-      Template::Plugin::URL 3.100
-      Template::Plugin::View 3.100
-      Template::Plugin::Wrap 3.100
-      Template::Plugins 3.100
-      Template::Provider 3.100
-      Template::Service 3.100
-      Template::Stash 3.100
-      Template::Stash::Context 3.100
+      Template 3.106
+      Template::App::ttree 3.106
+      Template::Base 3.106
+      Template::Config 3.106
+      Template::Constants 3.106
+      Template::Context 3.106
+      Template::Directive 3.106
+      Template::Document 3.106
+      Template::Exception 3.106
+      Template::Filters 3.106
+      Template::Grammar 3.106
+      Template::Iterator 3.106
+      Template::Monad::Assert 3.106
+      Template::Monad::Scalar 3.106
+      Template::Namespace::Constants 3.106
+      Template::Parser 3.106
+      Template::Perl 3.106
+      Template::Plugin 3.106
+      Template::Plugin::Assert 3.106
+      Template::Plugin::Datafile 3.106
+      Template::Plugin::Date 3.106
+      Template::Plugin::Date::Calc 3.106
+      Template::Plugin::Date::Manip 3.106
+      Template::Plugin::Directory 3.106
+      Template::Plugin::Dumper 3.106
+      Template::Plugin::File 3.106
+      Template::Plugin::Filter 3.106
+      Template::Plugin::Format 3.106
+      Template::Plugin::HTML 3.106
+      Template::Plugin::Image 3.106
+      Template::Plugin::Iterator 3.106
+      Template::Plugin::List 3.106
+      Template::Plugin::Math 3.106
+      Template::Plugin::Pod 3.106
+      Template::Plugin::Procedural 3.106
+      Template::Plugin::Scalar 3.106
+      Template::Plugin::String 3.106
+      Template::Plugin::Table 3.106
+      Template::Plugin::URL 3.106
+      Template::Plugin::View 3.106
+      Template::Plugin::Wrap 3.106
+      Template::Plugins 3.106
+      Template::Provider 3.106
+      Template::Service 3.106
+      Template::Stash 3.106
+      Template::Stash::Context 3.106
       Template::Stash::XS undef
-      Template::Test 3.100
-      Template::TieString 3.100
-      Template::Toolkit 3.100
-      Template::VMethods 3.100
-      Template::View 3.100
+      Template::Test 3.106
+      Template::TieString 3.106
+      Template::Toolkit 3.106
+      Template::VMethods 3.106
+      Template::View 3.106
     requirements:
       AppConfig 1.56
-      ExtUtils::MakeMaker 0
+      ExtUtils::MakeMaker 6.48
       File::Spec 0.8
       File::Temp 0.12
       Scalar::Util 0
+      perl 5.010
   Test-CPAN-Meta-0.25
     pathname: B/BA/BARBIE/Test-CPAN-Meta-0.25.tar.gz
     provides:
@@ -7338,11 +7344,11 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test::Builder 0.12
       Test::Builder::Tester 1.04
-  Test-Most-0.38
-    pathname: O/OV/OVID/Test-Most-0.38.tar.gz
+  Test-Most-0.42
+    pathname: D/DC/DCANTRELL/Test-Most-0.42.tar.gz
     provides:
-      Test::Most 0.38
-      Test::Most::Exception 0.38
+      Test::Most 0.42
+      Test::Most::Exception 0.42
     requirements:
       Exception::Class 1.14
       ExtUtils::MakeMaker 0
@@ -7493,10 +7499,10 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       Test::More 0
-  Text-CSV_XS-1.61
-    pathname: H/HM/HMBRAND/Text-CSV_XS-1.61.tgz
+  Text-CSV_XS-1.64
+    pathname: H/HM/HMBRAND/Text-CSV_XS-1.64.tgz
     provides:
-      Text::CSV_XS 1.61
+      Text::CSV_XS 1.64
     requirements:
       Config 0
       ExtUtils::MakeMaker 0
@@ -7633,50 +7639,53 @@ DISTRIBUTIONS
       Test::More 0
       Test::use::ok 0
       Tie::RefHash 0
-  TimeDate-2.33
-    pathname: A/AT/ATOOMIC/TimeDate-2.33.tar.gz
+  TimeDate-2.35
+    pathname: A/AT/ATOOMIC/TimeDate-2.35.tar.gz
     provides:
-      Date::Format 2.24
-      Date::Format::Generic 2.24
-      Date::Language 1.10
-      Date::Language::Afar 0.99
-      Date::Language::Amharic 1.00
-      Date::Language::Austrian 1.01
-      Date::Language::Brazilian 1.01
-      Date::Language::Bulgarian 1.01
-      Date::Language::Chinese 1.00
-      Date::Language::Chinese_GB 1.01
-      Date::Language::Czech 1.01
-      Date::Language::Danish 1.01
-      Date::Language::Dutch 1.02
-      Date::Language::English 1.01
-      Date::Language::Finnish 1.01
-      Date::Language::French 1.04
-      Date::Language::Gedeo 0.99
-      Date::Language::German 1.02
-      Date::Language::Greek 1.00
-      Date::Language::Hungarian 1.01
-      Date::Language::Icelandic 1.01
-      Date::Language::Italian 1.01
-      Date::Language::Norwegian 1.01
-      Date::Language::Occitan 1.04
-      Date::Language::Oromo 0.99
-      Date::Language::Romanian 1.01
-      Date::Language::Russian 1.01
-      Date::Language::Russian_cp1251 1.01
-      Date::Language::Russian_koi8r 1.01
-      Date::Language::Sidama 0.99
-      Date::Language::Somali 0.99
-      Date::Language::Spanish 1.00
-      Date::Language::Swedish 1.01
-      Date::Language::Tigrinya 1.00
-      Date::Language::TigrinyaEritrean 1.00
-      Date::Language::TigrinyaEthiopian 1.00
-      Date::Language::Turkish 1.0
-      Date::Parse 2.33
-      Time::Zone 2.24
-      TimeDate 1.21
+      Date::Format 2.35
+      Date::Format::Generic 2.35
+      Date::Language 2.35
+      Date::Language::Afar 2.35
+      Date::Language::Amharic 2.35
+      Date::Language::Arabic 2.35
+      Date::Language::Austrian 2.35
+      Date::Language::Brazilian 2.35
+      Date::Language::Bulgarian 2.35
+      Date::Language::Chinese 2.35
+      Date::Language::Chinese_GB 2.35
+      Date::Language::Czech 2.35
+      Date::Language::Danish 2.35
+      Date::Language::Dutch 2.35
+      Date::Language::English 2.35
+      Date::Language::Finnish 2.35
+      Date::Language::French 2.35
+      Date::Language::Gedeo 2.35
+      Date::Language::German 2.35
+      Date::Language::Greek 2.35
+      Date::Language::Hungarian 2.35
+      Date::Language::Icelandic 2.35
+      Date::Language::Italian 2.35
+      Date::Language::Norwegian 2.35
+      Date::Language::Occitan 2.35
+      Date::Language::Oromo 2.35
+      Date::Language::Portuguese 2.35
+      Date::Language::Romanian 2.35
+      Date::Language::Russian 2.35
+      Date::Language::Russian_cp1251 2.35
+      Date::Language::Russian_koi8r 2.35
+      Date::Language::Sidama 2.35
+      Date::Language::Somali 2.35
+      Date::Language::Spanish 2.35
+      Date::Language::Swedish 2.35
+      Date::Language::Tigrinya 2.35
+      Date::Language::TigrinyaEritrean 2.35
+      Date::Language::TigrinyaEthiopian 2.35
+      Date::Language::Turkish 2.35
+      Date::Parse 2.35
+      Time::Zone 2.35
+      TimeDate 2.35
     requirements:
+      Carp 0
       ExtUtils::MakeMaker 0
   Try-Tiny-0.32
     pathname: E/ET/ETHER/Try-Tiny-0.32.tar.gz
@@ -7690,60 +7699,60 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Type-Tiny-2.008006
-    pathname: T/TO/TOBYINK/Type-Tiny-2.008006.tar.gz
+  Type-Tiny-2.010001
+    pathname: T/TO/TOBYINK/Type-Tiny-2.010001.tar.gz
     provides:
-      Devel::TypeTiny::Perl58Compat 2.008006
-      Error::TypeTiny 2.008006
-      Error::TypeTiny::Assertion 2.008006
-      Error::TypeTiny::Compilation 2.008006
-      Error::TypeTiny::WrongNumberOfParameters 2.008006
-      Eval::TypeTiny 2.008006
-      Eval::TypeTiny::CodeAccumulator 2.008006
-      Reply::Plugin::TypeTiny 2.008006
-      Test::TypeTiny 2.008006
-      Type::Coercion 2.008006
-      Type::Coercion::FromMoose 2.008006
-      Type::Coercion::Union 2.008006
-      Type::Library 2.008006
-      Type::Params 2.008006
-      Type::Params::Alternatives 2.008006
-      Type::Params::Parameter 2.008006
-      Type::Params::Signature 2.008006
-      Type::Parser 2.008006
-      Type::Parser::AstBuilder 2.008006
-      Type::Parser::Token 2.008006
-      Type::Parser::TokenStream 2.008006
-      Type::Registry 2.008006
-      Type::Tie 2.008006
-      Type::Tie::ARRAY 2.008006
-      Type::Tie::BASE 2.008006
-      Type::Tie::HASH 2.008006
-      Type::Tie::SCALAR 2.008006
-      Type::Tiny 2.008006
-      Type::Tiny::Bitfield 2.008006
-      Type::Tiny::Class 2.008006
-      Type::Tiny::ConstrainedObject 2.008006
-      Type::Tiny::Duck 2.008006
-      Type::Tiny::Enum 2.008006
-      Type::Tiny::Intersection 2.008006
-      Type::Tiny::Role 2.008006
-      Type::Tiny::Union 2.008006
-      Type::Utils 2.008006
-      Types::Common 2.008006
-      Types::Common::Numeric 2.008006
-      Types::Common::String 2.008006
-      Types::Standard 2.008006
-      Types::Standard::ArrayRef 2.008006
-      Types::Standard::CycleTuple 2.008006
-      Types::Standard::Dict 2.008006
-      Types::Standard::HashRef 2.008006
-      Types::Standard::Map 2.008006
-      Types::Standard::ScalarRef 2.008006
-      Types::Standard::StrMatch 2.008006
-      Types::Standard::Tied 2.008006
-      Types::Standard::Tuple 2.008006
-      Types::TypeTiny 2.008006
+      Devel::TypeTiny::Perl58Compat 2.010001
+      Error::TypeTiny 2.010001
+      Error::TypeTiny::Assertion 2.010001
+      Error::TypeTiny::Compilation 2.010001
+      Error::TypeTiny::WrongNumberOfParameters 2.010001
+      Eval::TypeTiny 2.010001
+      Eval::TypeTiny::CodeAccumulator 2.010001
+      Reply::Plugin::TypeTiny 2.010001
+      Test::TypeTiny 2.010001
+      Type::Coercion 2.010001
+      Type::Coercion::FromMoose 2.010001
+      Type::Coercion::Union 2.010001
+      Type::Library 2.010001
+      Type::Params 2.010001
+      Type::Params::Alternatives 2.010001
+      Type::Params::Parameter 2.010001
+      Type::Params::Signature 2.010001
+      Type::Parser 2.010001
+      Type::Parser::AstBuilder 2.010001
+      Type::Parser::Token 2.010001
+      Type::Parser::TokenStream 2.010001
+      Type::Registry 2.010001
+      Type::Tie 2.010001
+      Type::Tie::ARRAY 2.010001
+      Type::Tie::BASE 2.010001
+      Type::Tie::HASH 2.010001
+      Type::Tie::SCALAR 2.010001
+      Type::Tiny 2.010001
+      Type::Tiny::Bitfield 2.010001
+      Type::Tiny::Class 2.010001
+      Type::Tiny::ConstrainedObject 2.010001
+      Type::Tiny::Duck 2.010001
+      Type::Tiny::Enum 2.010001
+      Type::Tiny::Intersection 2.010001
+      Type::Tiny::Role 2.010001
+      Type::Tiny::Union 2.010001
+      Type::Utils 2.010001
+      Types::Common 2.010001
+      Types::Common::Numeric 2.010001
+      Types::Common::String 2.010001
+      Types::Standard 2.010001
+      Types::Standard::ArrayRef 2.010001
+      Types::Standard::CycleTuple 2.010001
+      Types::Standard::Dict 2.010001
+      Types::Standard::HashRef 2.010001
+      Types::Standard::Map 2.010001
+      Types::Standard::ScalarRef 2.010001
+      Types::Standard::StrMatch 2.010001
+      Types::Standard::Tied 2.010001
+      Types::Standard::Tuple 2.010001
+      Types::TypeTiny 2.010001
     requirements:
       Exporter::Tiny 1.006000
       ExtUtils::MakeMaker 6.17
@@ -7758,66 +7767,66 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       common::sense 0
-  URI-5.34
-    pathname: O/OA/OALDERS/URI-5.34.tar.gz
+  URI-5.35
+    pathname: O/OA/OALDERS/URI-5.35.tar.gz
     provides:
-      URI 5.34
-      URI::Escape 5.34
-      URI::Heuristic 5.34
-      URI::IRI 5.34
-      URI::QueryParam 5.34
-      URI::Split 5.34
-      URI::URL 5.34
-      URI::WithBase 5.34
-      URI::data 5.34
-      URI::file 5.34
-      URI::file::Base 5.34
-      URI::file::FAT 5.34
-      URI::file::Mac 5.34
-      URI::file::OS2 5.34
-      URI::file::QNX 5.34
-      URI::file::Unix 5.34
-      URI::file::Win32 5.34
-      URI::ftp 5.34
-      URI::ftpes 5.34
-      URI::ftps 5.34
-      URI::geo 5.34
-      URI::gopher 5.34
-      URI::http 5.34
-      URI::https 5.34
-      URI::icap 5.34
-      URI::icaps 5.34
-      URI::irc 5.34
-      URI::ircs 5.34
-      URI::ldap 5.34
-      URI::ldapi 5.34
-      URI::ldaps 5.34
-      URI::mailto 5.34
-      URI::mms 5.34
-      URI::news 5.34
-      URI::nntp 5.34
-      URI::nntps 5.34
-      URI::otpauth 5.34
-      URI::pop 5.34
-      URI::rlogin 5.34
-      URI::rsync 5.34
-      URI::rtsp 5.34
-      URI::rtspu 5.34
-      URI::scp 5.34
-      URI::sftp 5.34
-      URI::sip 5.34
-      URI::sips 5.34
-      URI::smb 5.34
-      URI::smtp 5.34
-      URI::snews 5.34
-      URI::ssh 5.34
-      URI::telnet 5.34
-      URI::tn3270 5.34
-      URI::urn 5.34
-      URI::urn::isbn 5.34
-      URI::urn::oid 5.34
-      URI::ws 5.34
-      URI::wss 5.34
+      URI 5.35
+      URI::Escape 5.35
+      URI::Heuristic 5.35
+      URI::IRI 5.35
+      URI::QueryParam 5.35
+      URI::Split 5.35
+      URI::URL 5.35
+      URI::WithBase 5.35
+      URI::data 5.35
+      URI::file 5.35
+      URI::file::Base 5.35
+      URI::file::FAT 5.35
+      URI::file::Mac 5.35
+      URI::file::OS2 5.35
+      URI::file::QNX 5.35
+      URI::file::Unix 5.35
+      URI::file::Win32 5.35
+      URI::ftp 5.35
+      URI::ftpes 5.35
+      URI::ftps 5.35
+      URI::geo 5.35
+      URI::gopher 5.35
+      URI::http 5.35
+      URI::https 5.35
+      URI::icap 5.35
+      URI::icaps 5.35
+      URI::irc 5.35
+      URI::ircs 5.35
+      URI::ldap 5.35
+      URI::ldapi 5.35
+      URI::ldaps 5.35
+      URI::mailto 5.35
+      URI::mms 5.35
+      URI::news 5.35
+      URI::nntp 5.35
+      URI::nntps 5.35
+      URI::otpauth 5.35
+      URI::pop 5.35
+      URI::rlogin 5.35
+      URI::rsync 5.35
+      URI::rtsp 5.35
+      URI::rtspu 5.35
+      URI::scp 5.35
+      URI::sftp 5.35
+      URI::sip 5.35
+      URI::sips 5.35
+      URI::smb 5.35
+      URI::smtp 5.35
+      URI::snews 5.35
+      URI::ssh 5.35
+      URI::telnet 5.35
+      URI::tn3270 5.35
+      URI::urn 5.35
+      URI::urn::isbn 5.35
+      URI::urn::oid 5.35
+      URI::ws 5.35
+      URI::wss 5.35
     requirements:
       Carp 0
       Cwd 0
@@ -7897,18 +7906,21 @@ DISTRIBUTIONS
       Exporter 0
       Module::Build 0.4005
       perl 5.008001
-  WWW-RobotRules-6.02
-    pathname: G/GA/GAAS/WWW-RobotRules-6.02.tar.gz
+  WWW-RobotRules-6.03
+    pathname: O/OA/OALDERS/WWW-RobotRules-6.03.tar.gz
     provides:
-      WWW::RobotRules 6.02
-      WWW::RobotRules::AnyDBM_File 6.00
-      WWW::RobotRules::InCore 6.02
+      WWW::RobotRules 6.03
+      WWW::RobotRules::AnyDBM_File 6.03
+      WWW::RobotRules::DB_File 6.03
+      WWW::RobotRules::InCore 6.03
     requirements:
       AnyDBM_File 0
+      Carp 0
       ExtUtils::MakeMaker 0
       Fcntl 0
       URI 1.10
       perl 5.008001
+      strict 0
   XML-NamespaceSupport-1.12
     pathname: P/PE/PERIGRIN/XML-NamespaceSupport-1.12.tar.gz
     provides:
@@ -7920,11 +7932,11 @@ DISTRIBUTIONS
       strict 0
       vars 0
       warnings 0
-  XML-Parser-2.47
-    pathname: T/TO/TODDR/XML-Parser-2.47.tar.gz
+  XML-Parser-2.59
+    pathname: T/TO/TODDR/XML-Parser-2.59.tar.gz
     provides:
-      XML::Parser 2.47
-      XML::Parser::Expat 2.47
+      XML::Parser 2.59
+      XML::Parser::Expat 2.59
       XML::Parser::Style::Debug undef
       XML::Parser::Style::Objects undef
       XML::Parser::Style::Stream undef
@@ -7932,8 +7944,9 @@ DISTRIBUTIONS
       XML::Parser::Style::Tree undef
     requirements:
       ExtUtils::MakeMaker 0
-      LWP::UserAgent 0
-      perl 5.004050
+      File::ShareDir 0
+      File::ShareDir::Install 0.06
+      perl 5.008
   XML-SAX-1.02
     pathname: G/GR/GRANTM/XML-SAX-1.02.tar.gz
     provides:
@@ -8033,11 +8046,84 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.008
-  YAML-1.31
-    pathname: I/IN/INGY/YAML-1.31.tar.gz
+  YAML-LibYAML-v0.910.0
+    pathname: T/TI/TINITA/YAML-LibYAML-v0.910.0.tar.gz
     provides:
-      YAML 1.31
-      YAML::Any 1.31
+      YAML::LibYAML v0.910.0
+      YAML::XS v0.910.0
+      YAML::XS::LibYAML v0.910.0
+    requirements:
+      B::Deparse 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Scalar::Util 0
+      base 0
+      constant 0
+      perl 5.008001
+      strict 0
+      warnings 0
+  YAML-PP-v0.41.0
+    pathname: T/TI/TINITA/YAML-PP-v0.41.0.tar.gz
+    provides:
+      YAML::PP v0.41.0
+      YAML::PP::Common v0.41.0
+      YAML::PP::Constructor v0.41.0
+      YAML::PP::Dumper v0.41.0
+      YAML::PP::Emitter v0.41.0
+      YAML::PP::Exception v0.41.0
+      YAML::PP::Grammar v0.41.0
+      YAML::PP::Highlight v0.41.0
+      YAML::PP::Lexer v0.41.0
+      YAML::PP::Loader v0.41.0
+      YAML::PP::Parser v0.41.0
+      YAML::PP::Perl v0.41.0
+      YAML::PP::Preserve::Array v0.41.0
+      YAML::PP::Preserve::Hash v0.41.0
+      YAML::PP::Preserve::Scalar v0.41.0
+      YAML::PP::Reader v0.41.0
+      YAML::PP::Reader::File v0.41.0
+      YAML::PP::Render v0.41.0
+      YAML::PP::Representer v0.41.0
+      YAML::PP::Schema v0.41.0
+      YAML::PP::Schema::Binary v0.41.0
+      YAML::PP::Schema::Catchall v0.41.0
+      YAML::PP::Schema::Core v0.41.0
+      YAML::PP::Schema::Failsafe v0.41.0
+      YAML::PP::Schema::Include v0.41.0
+      YAML::PP::Schema::JSON v0.41.0
+      YAML::PP::Schema::Merge v0.41.0
+      YAML::PP::Schema::Perl v0.41.0
+      YAML::PP::Schema::Tie::IxHash v0.41.0
+      YAML::PP::Schema::YAML1_1 v0.41.0
+      YAML::PP::Type::MergeKey v0.41.0
+      YAML::PP::Writer v0.41.0
+      YAML::PP::Writer::File v0.41.0
+    requirements:
+      B 0
+      B::Deparse 0
+      Carp 0
+      Data::Dumper 0
+      Encode 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      Getopt::Long 0
+      MIME::Base64 0
+      Module::Load 0
+      Scalar::Util 1.07
+      Tie::Array 0
+      Tie::Hash 0
+      base 0
+      constant 0
+      overload 0
+      perl 5.008000
+      strict 0
+      warnings 0
+  YAML-v1.320.0
+    pathname: T/TI/TINITA/YAML-v1.320.0.tar.gz
+    provides:
+      YAML 1.320000
+      YAML::Any 1.320000
       YAML::Dumper undef
       YAML::Dumper::Base undef
       YAML::Error undef
@@ -8061,78 +8147,6 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.008001
-  YAML-LibYAML-v0.904.0
-    pathname: T/TI/TINITA/YAML-LibYAML-v0.904.0.tar.gz
-    provides:
-      YAML::LibYAML v0.904.0
-      YAML::XS v0.904.0
-    requirements:
-      B::Deparse 0
-      Exporter 0
-      ExtUtils::MakeMaker 0
-      Scalar::Util 0
-      base 0
-      constant 0
-      perl 5.008001
-      strict 0
-      warnings 0
-  YAML-PP-v0.39.0
-    pathname: T/TI/TINITA/YAML-PP-v0.39.0.tar.gz
-    provides:
-      YAML::PP v0.39.0
-      YAML::PP::Common v0.39.0
-      YAML::PP::Constructor v0.39.0
-      YAML::PP::Dumper v0.39.0
-      YAML::PP::Emitter v0.39.0
-      YAML::PP::Exception v0.39.0
-      YAML::PP::Grammar v0.39.0
-      YAML::PP::Highlight v0.39.0
-      YAML::PP::Lexer v0.39.0
-      YAML::PP::Loader v0.39.0
-      YAML::PP::Parser v0.39.0
-      YAML::PP::Perl v0.39.0
-      YAML::PP::Preserve::Array v0.39.0
-      YAML::PP::Preserve::Hash v0.39.0
-      YAML::PP::Preserve::Scalar v0.39.0
-      YAML::PP::Reader v0.39.0
-      YAML::PP::Reader::File v0.39.0
-      YAML::PP::Render v0.39.0
-      YAML::PP::Representer v0.39.0
-      YAML::PP::Schema v0.39.0
-      YAML::PP::Schema::Binary v0.39.0
-      YAML::PP::Schema::Catchall v0.39.0
-      YAML::PP::Schema::Core v0.39.0
-      YAML::PP::Schema::Failsafe v0.39.0
-      YAML::PP::Schema::Include v0.39.0
-      YAML::PP::Schema::JSON v0.39.0
-      YAML::PP::Schema::Merge v0.39.0
-      YAML::PP::Schema::Perl v0.39.0
-      YAML::PP::Schema::Tie::IxHash v0.39.0
-      YAML::PP::Schema::YAML1_1 v0.39.0
-      YAML::PP::Type::MergeKey v0.39.0
-      YAML::PP::Writer v0.39.0
-      YAML::PP::Writer::File v0.39.0
-    requirements:
-      B 0
-      B::Deparse 0
-      Carp 0
-      Data::Dumper 0
-      Encode 0
-      Exporter 0
-      ExtUtils::MakeMaker 0
-      File::Basename 0
-      Getopt::Long 0
-      MIME::Base64 0
-      Module::Load 0
-      Scalar::Util 1.07
-      Tie::Array 0
-      Tie::Hash 0
-      base 0
-      constant 0
-      overload 0
-      perl 5.008000
-      strict 0
-      warnings 0
   bareword-filehandles-0.007
     pathname: I/IL/ILMARI/bareword-filehandles-0.007.tar.gz
     provides:
@@ -8171,32 +8185,32 @@ DISTRIBUTIONS
       XSLoader 0
       lib 0
       perl 5.008001
-  libwww-perl-6.81
-    pathname: O/OA/OALDERS/libwww-perl-6.81.tar.gz
+  libwww-perl-6.83
+    pathname: O/OA/OALDERS/libwww-perl-6.83.tar.gz
     provides:
-      LWP 6.81
-      LWP::Authen::Basic 6.81
-      LWP::Authen::Digest 6.81
-      LWP::Authen::Ntlm 6.81
-      LWP::ConnCache 6.81
-      LWP::Debug 6.81
-      LWP::Debug::TraceHTTP 6.81
-      LWP::DebugFile 6.81
-      LWP::MemberMixin 6.81
-      LWP::Protocol 6.81
-      LWP::Protocol::cpan 6.81
-      LWP::Protocol::data 6.81
-      LWP::Protocol::file 6.81
-      LWP::Protocol::ftp 6.81
-      LWP::Protocol::gopher 6.81
-      LWP::Protocol::http 6.81
-      LWP::Protocol::loopback 6.81
-      LWP::Protocol::mailto 6.81
-      LWP::Protocol::nntp 6.81
-      LWP::Protocol::nogo 6.81
-      LWP::RobotUA 6.81
-      LWP::Simple 6.81
-      LWP::UserAgent 6.81
+      LWP 6.83
+      LWP::Authen::Basic 6.83
+      LWP::Authen::Digest 6.83
+      LWP::Authen::Ntlm 6.83
+      LWP::ConnCache 6.83
+      LWP::Debug 6.83
+      LWP::Debug::TraceHTTP 6.83
+      LWP::DebugFile 6.83
+      LWP::MemberMixin 6.83
+      LWP::Protocol 6.83
+      LWP::Protocol::cpan 6.83
+      LWP::Protocol::data 6.83
+      LWP::Protocol::file 6.83
+      LWP::Protocol::ftp 6.83
+      LWP::Protocol::gopher 6.83
+      LWP::Protocol::http 6.83
+      LWP::Protocol::loopback 6.83
+      LWP::Protocol::mailto 6.83
+      LWP::Protocol::nntp 6.83
+      LWP::Protocol::nogo 6.83
+      LWP::RobotUA 6.83
+      LWP::Simple 6.83
+      LWP::UserAgent 6.83
     requirements:
       Digest::MD5 0
       Encode 2.12


### PR DESCRIPTION
- Many updates to various dependencies
- Workarounds were added to fix some build issues with newer Perl version