### PR TITLE
Bug 2058149 - Remove Enterprise Products from the release tracking request automation

### DIFF
--- a/Bugzilla/Bug.pm
+++ b/Bugzilla/Bug.pm
@@ -607,7 +607,7 @@ sub possible_duplicates {
   my $products   = $params->{products} || [];
   my $limit      = $params->{limit} || MAX_POSSIBLE_DUPLICATES;
   $limit    = MAX_POSSIBLE_DUPLICATES if $limit > MAX_POSSIBLE_DUPLICATES;
-  $products = [$products]             if !ref($products) eq 'ARRAY';
+  $products = [$products]             if !ref($products) || ref($products) ne 'ARRAY';
 
   my $orig_limit = $limit;
   detaint_natural($limit)

--- a/Bugzilla/Template/Plugin/Hook.pm
+++ b/Bugzilla/Template/Plugin/Hook.pm
@@ -33,7 +33,7 @@ sub process {
   $template ||= $context->stash->{component}->{name};
 
   # sanity check:
-  if (!$template =~ /[\w\.\/\-_\\]+/) {
+  if ($template !~ /[\w\.\/\-_\\]+/) {
     ThrowCodeError('template_invalid', {name => $template});
   }
 

--- a/extensions/MozChangeField/lib/Post/SetTrackingSeverityS1.pm
+++ b/extensions/MozChangeField/lib/Post/SetTrackingSeverityS1.pm
@@ -14,10 +14,22 @@ use Bugzilla::Extension::TrackingFlags::Flag;
 use Bugzilla::Extension::TrackingFlags::Flag::Bug;
 use Bugzilla::Util qw(fetch_product_versions);
 
+# Products that are not relevant to Firefox release management and so should
+# never have their nightly/beta tracking flags set automatically.
+use constant EXCLUDED_PRODUCTS => ('Enterprise Products');
+
+sub _is_excluded_product {
+  my ($self, $bug) = @_;
+  my $product = $bug->product;
+  return grep { $_ eq $product } EXCLUDED_PRODUCTS;
+}
+
 sub evaluate_create {
   my ($self, $args) = @_;
   my $bug       = $args->{bug};
   my $timestamp = $args->{timestamp};
+
+  return if $self->_is_excluded_product($bug);
 
   if ($bug->bug_severity eq 'S1') {
     my $cache    = Bugzilla->request_cache->{tracking_flags_create_params};
@@ -59,6 +71,8 @@ sub evaluate_change {
   my ($self, $args) = @_;
   my ($bug, $old_bug, $timestamp, $changes)
     = @$args{qw(bug old_bug timestamp changes)};
+
+  return if $self->_is_excluded_product($bug);
 
   if ( $changes
     && exists $changes->{bug_severity}
@@ -116,11 +130,11 @@ sub evaluate_change {
 }
 
 sub _fetch_nightly_beta_versions {
-  my $versions  = fetch_product_versions('firefox');
-  if (!$versions
+  my $versions = fetch_product_versions('firefox');
+  if ( !$versions
     || !exists $versions->{FIREFOX_NIGHTLY}
-    || !exists $versions->{LATEST_FIREFOX_RELEASED_DEVEL_VERSION}
-  ) {
+    || !exists $versions->{LATEST_FIREFOX_RELEASED_DEVEL_VERSION})
+  {
     return {nightly => 0, beta => 0};
   }
   my ($nightly) = split /\./, $versions->{FIREFOX_NIGHTLY};


### PR DESCRIPTION
Not admin config — it's code. extensions/MozChangeField/lib/Post/SetTrackingSeverityS1.pm runs on bug create and on severity change, sets current nightly/beta cf_tracking_firefox<N> to ?.

Change: early return in both evaluate_create and evaluate_change when product is in EXCLUDED_PRODUCTS constant (currently just 'Enterprise Products'). Adding more later = one string in the list, or swap constant for a param when you want it admin-editable.

Notes:
- evaluate_change checks $bug->product = new product, so a bug moved into Enterprise Products in same transaction as the S1 set is also skipped.
- EXCLUDED_PRODUCTS is a list constant, so grep works and stays cheap