### PR TITLE
Bug 1202436 - Document authentication method precedence

### DIFF
--- a/docs/en/rst/api/core/v1/general.rst
+++ b/docs/en/rst/api/core/v1/general.rst
@@ -110,6 +110,19 @@ any request, and you will be authenticated as that user if the key is correct an
 You can set up an API key by using the :ref:`API Keys tab <api-keys>` in the
 Preferences pages.
 
+Send only one authentication method with each request. BMO does not combine
+credentials or choose the strongest method when more than one is supplied. In
+particular, legacy ``Bugzilla_login`` and ``Bugzilla_password`` credentials take
+precedence over an API key. Once BMO selects those credentials, it does not fall
+back to the API key if password authentication fails.
+
+If the account has the :guilabel:`Require API key authentication for API
+requests` preference enabled, a request containing both valid username/password
+credentials and a valid API key fails with an ``API key authentication is
+required`` error because BMO selected the username/password credentials first.
+Remove the username/password credentials and send only the API key; do not
+disable the preference.
+
 **WARNING**: It should be noted that additional authentication methods exist, but they are **not recommended** for use and are likely to be deprecated in future versions of BMO, due to security concerns.  These additional methods include the following:
 
  - api key via ``Bugzilla_api_key`` or simply ``api_key`` in query parameters.


### PR DESCRIPTION
Bug 1202436 tracks missing REST API documentation for requests that provide more than one authentication method. BMO evaluates legacy username/password credentials before API keys, so a valid API key can be ignored. When the account requires API-key authentication, the mixed request fails with an `API key authentication is required` error.

This documents the precedence, lack of fallback, and interaction with the `Require API key authentication for API requests` preference. It advises clients to send only the `X-BUGZILLA-API-KEY` header rather than disabling the preference. Authentication behavior is unchanged.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1202436

Testing:

- Built the Sphinx HTML documentation with the pinned requirements. The build succeeded with six pre-existing warnings.